### PR TITLE
Update name with address tile

### DIFF
--- a/consultations_prj/media/css/project.css
+++ b/consultations_prj/media/css/project.css
@@ -324,3 +324,10 @@ div.active-cons-stub-label {
 li.workflow-main-nav-item a {
     display: block;
 }
+
+div.hide-address-name div:nth-child(3) > form:nth-child(2) > div:nth-child(1) {
+    visibility: hidden;
+    height: 0;
+    padding: 0;
+    width: 0;
+}

--- a/consultations_prj/media/js/views/components/plugins/consultation-workflow.js
+++ b/consultations_prj/media/js/views/components/plugins/consultation-workflow.js
@@ -36,6 +36,7 @@ define([
                     tileid: null,
                     parenttileid: null,
                     icon: 'fa-tag'
+                    class: 'hide-address-name'
                 },
                 {
                     title: 'Related Application Area',

--- a/consultations_prj/media/js/views/components/plugins/consultation-workflow.js
+++ b/consultations_prj/media/js/views/components/plugins/consultation-workflow.js
@@ -17,25 +17,16 @@ define([
                     componentname: 'get-tile-value',
                     graphid: '08359c2e-53f0-11e9-b212-dca90488358a',
                     nodegroupid: '9dc86b0c-6c48-11e9-8cbe-dca90488358a',
+                    nodegroups: ['9dc86b0c-6c48-11e9-8cbe-dca90488358a', 'e6f0688a-53f1-11e9-93a2-dca90488358a'],
                     resourceid: null,
                     tileid: null,
+                    tileids: [],
                     parenttileid: null,
                     icon: 'fa-envelope',
                     nameheading: 'Consultation Name',
-                    namelabel: 'Make the Consultation Name the same as the Consultation Address'
-                },
-                {
-                    title: 'Assign Name',
-                    name: 'setname',
-                    description: 'Assign a name to your application area',
-                    component: 'views/components/workflows/set-tile-value',
-                    componentname: 'set-tile-value',
-                    graphid: '08359c2e-53f0-11e9-b212-dca90488358a',
-                    nodegroupid: 'e6f0688a-53f1-11e9-93a2-dca90488358a',
-                    resourceid: null,
-                    tileid: null,
-                    parenttileid: null,
-                    icon: 'fa-tag'
+                    namelabel: 'Make the Consultation Name the same as the Consultation Address',
+                    targetnode: 'e6f0688a-53f1-11e9-93a2-dca90488358a',
+                    targetnodegroup: 'e6f0688a-53f1-11e9-93a2-dca90488358a',
                     class: 'hide-address-name'
                 },
                 {
@@ -160,15 +151,6 @@ define([
                 } else {
                     activeStep.requirements = self.state.steps[activeStep._index] || {};
                     activeStep.requirements.resourceid = self.state.resourceid;
-                } if (activeStep._index === 1) {
-                    var tiledata = self.state.steps[0].tile
-                    var tilevals = _.map(tiledata, function(v, k) {return v})
-                    var nodeval = tilevals[2] + ", " + tilevals[0] + " " + tilevals[1];
-                    activeStep.requirements.applyOutputToTarget = self.state.steps[0].applyOutputToTarget;
-                    activeStep.requirements.resourceid = self.state.steps[0].resourceid;
-                    activeStep.requirements.targetnode = 'e6f0688a-53f1-11e9-93a2-dca90488358a';
-                    activeStep.requirements.targetnodegroup = ko.unwrap(activeStep.nodegroupid);
-                    activeStep.requirements.value = nodeval;
                 }
                 self.previousStep(activeStep);
             }

--- a/consultations_prj/media/js/views/components/workflows/get-tile-value.js
+++ b/consultations_prj/media/js/views/components/workflows/get-tile-value.js
@@ -4,11 +4,11 @@ define([
     'arches',
     'knockout',
     'knockout-mapping',
-    'views/components/workflows/group-tile-step'
-], function(_, $, arches, ko, koMapping, GroupTileStep) {
+    'views/components/workflows/new-tile-step'
+], function(_, $, arches, ko, koMapping, NewTileStep) {
     function viewModel(params) {
         var self = this;
-        GroupTileStep.apply(this, [params]);
+        NewTileStep.apply(this, [params]);
         params.applyOutputToTarget = ko.observable(true);
         if (!params.resourceid() && params.requirements){
             params.resourceid(params.requirements.resourceid);

--- a/consultations_prj/media/js/views/components/workflows/get-tile-value.js
+++ b/consultations_prj/media/js/views/components/workflows/get-tile-value.js
@@ -4,22 +4,24 @@ define([
     'arches',
     'knockout',
     'knockout-mapping',
-    'views/components/workflows/new-tile-step'
-], function(_, $, arches, ko, koMapping, NewTileStep) {
+    'views/components/workflows/group-tile-step'
+], function(_, $, arches, ko, koMapping, GroupTileStep) {
     function viewModel(params) {
         var self = this;
+        GroupTileStep.apply(this, [params]);
         params.applyOutputToTarget = ko.observable(true);
-
         if (!params.resourceid() && params.requirements){
             params.resourceid(params.requirements.resourceid);
             params.tileid(params.requirements.tileid);
         }
-
-        NewTileStep.apply(this, [params]);
-
         this.nameheading = params.nameheading;
         this.namelabel = params.namelabel;
         this.applyOutputToTarget = params.applyOutputToTarget;
+
+        this.workflowStepClass = ko.pureComputed(function() {
+            return self.applyOutputToTarget() ? params.class() : '';
+        }, viewModel);
+
         params.tile = self.tile;
 
         params.stateProperties = function(){
@@ -30,8 +32,43 @@ define([
                     applyOutputToTarget: ko.unwrap(this.applyOutputToTarget)
                 }
             };
-    };
 
+        self.updateTargetTile = function(tiles){
+            var targetresult;
+            var targettile;
+            var sourcetile;
+            var targetvals;
+            tiles.forEach(function(tile){
+                    if (tile.nodegroup_id === ko.unwrap(params.targetnodegroup)) {
+                        targettile = tile;
+                    } else if (tile.nodegroup_id === ko.unwrap(params.nodegroupid)) {
+                        sourcetile = tile;
+                    }
+                });
+            targetvals = _.map(sourcetile.data, function(v, k) {return ko.unwrap(v)})
+            targetresult = targetvals[2] + ", " + targetvals[0] + " " + targetvals[1];
+            targettile.data[params.targetnode()](targetresult);
+            targettile.save();
+        };
+
+        self.applyOutputToTarget.subscribe(function(val){
+            if (val && self.tiles.length > 0) {
+                self.updateTargetTile(self.tiles);
+            }
+        });
+
+        self.onSaveSuccess = function(tiles) {
+            self.tiles = tiles;
+            params.resourceid(tiles[0].resourceinstance_id);
+            self.resourceId(tiles[0].resourceinstance_id);
+            if (self.applyOutputToTarget()) {
+                self.updateTargetTile(tiles)
+            };
+            if (self.completeOnSave === true) {
+                self.complete(true);
+            }
+        }
+    };
 
     return ko.components.register('get-tile-value', {
         viewModel: viewModel,

--- a/consultations_prj/media/js/views/components/workflows/get-tile-value.js
+++ b/consultations_prj/media/js/views/components/workflows/get-tile-value.js
@@ -52,18 +52,20 @@ define([
         };
 
         self.applyOutputToTarget.subscribe(function(val){
-            if (val && self.tiles.length > 0) {
+            if (val && self.tiles && self.tiles.length > 0) {
                 self.updateTargetTile(self.tiles);
             }
         });
 
         self.onSaveSuccess = function(tiles) {
             self.tiles = tiles;
-            params.resourceid(tiles[0].resourceinstance_id);
-            self.resourceId(tiles[0].resourceinstance_id);
+            if (self.tiles.length > 0) {
+                params.resourceid(tiles[0].resourceinstance_id);
+                self.resourceId(tiles[0].resourceinstance_id);
+            }
             if (self.applyOutputToTarget()) {
                 self.updateTargetTile(tiles)
-            };
+            }
             if (self.completeOnSave === true) {
                 self.complete(true);
             }

--- a/consultations_prj/templates/views/components/plugins/init-workflow.htm
+++ b/consultations_prj/templates/views/components/plugins/init-workflow.htm
@@ -4,7 +4,7 @@
     </div>
     <div class="workflow-select-card-container">
         <!-- ko foreach: {data: workflows, as: 'workflow'} -->
-        <a data-bind="attr: {href: workflow.url, title: workflow.name, target: '_blank'}" href="#"><div data-bind="style: {'background-color': workflow.bgColor}" class="workflow-select-card">
+        <a data-bind="attr: {href: workflow.url, title: workflow.name}" href="#"><div data-bind="style: {'background-color': workflow.bgColor}" class="workflow-select-card">
             <h4 class="workflow-select-title" data-bind="text: workflow.name"></h4>
             <div data-bind="style: {'background-color': workflow.circleColor}" class="workflow-select-wf-circle">
                 <span><i data-bind="attr:{class: ('fa '+workflow.icon +' workflow-select-wf-icon')}"></i></span>

--- a/consultations_prj/templates/views/components/workflows/get-tile-value.htm
+++ b/consultations_prj/templates/views/components/workflows/get-tile-value.htm
@@ -1,5 +1,5 @@
 <!-- ko if: tile() && card() -->
-<div class="padded-workflow-step">    
+<div class="padded-workflow-step">
     <div class="workflows-get-tile-value"><h4 data-bind="text: nameheading"></h4>
         <div class="checkbox">
             <label class="form-checkbox form-normal form-primary" data-bind="css: {'active': applyOutputToTarget}" style="padding-left: 25px; padding-top: 3px;">
@@ -8,18 +8,19 @@
             </label>
         </div>
     </div>
-
-    <div data-bind="component: {
-        name: cardComponentLookup[card().model.component_id()].componentname,
-        params: {
-            card: card(),
-            tile: tile(),
-            provisionalTileViewModel: provisionalTileViewModel,
-            reviewer: reviewer,
-            loading: loading,
-            form: $data
-        }
-    }">
+    <div data-bind="class: workflowStepClass">
+        <div data-bind="component: {
+            name: cardComponentLookup[card().model.component_id()].componentname,
+            params: {
+                card: card(),
+                tile: tile(),
+                provisionalTileViewModel: provisionalTileViewModel,
+                reviewer: reviewer,
+                loading: loading,
+                form: $data
+            }
+        }">
+        </div>
     </div>
 </div>
 <!-- /ko -->


### PR DESCRIPTION
Removes step managing name card in the consultations workflow and replaces it with logic in the first workflow step to save the name tile with the address tile data. re #79