### PR TITLE
107 calc consultation name

### DIFF
--- a/consultations_prj/media/js/views/components/plugins/consultation-workflow.js
+++ b/consultations_prj/media/js/views/components/plugins/consultation-workflow.js
@@ -35,8 +35,11 @@ define([
                     parenttileid: null,
                     icon: 'fa-tag',
                     config: {
-                        fn:function(){},
-                        sourcenodeids: ["8d41e4ba-a250-11e9-9b20-00224800b26d"]
+                        fn:function(args){ // # of (k,v) == sourcenodeids.length
+                            var name = args["8d41e4ba-a250-11e9-9b20-00224800b26d"];
+                            return ('consultation for '+name); },
+                        sourcenodeids: ["8d41e4ba-a250-11e9-9b20-00224800b26d"],
+                        targetnodeid: "8d41e4ab-a250-11e9-87d1-00224800b26d"
                     }
                 },
                 {

--- a/consultations_prj/media/js/views/components/plugins/consultation-workflow.js
+++ b/consultations_prj/media/js/views/components/plugins/consultation-workflow.js
@@ -1,8 +1,10 @@
 define([
     'knockout',
+    'jquery',
+    'arches',
     'viewmodels/workflow',
     'viewmodels/workflow-step'
-], function(ko, Workflow, Step) {
+], function(ko, $, arches, Workflow, Step) {
     return ko.components.register('consultation-workflow', {
         viewModel: function(params) {
 
@@ -35,9 +37,15 @@ define([
                     parenttileid: null,
                     icon: 'fa-tag',
                     config: {
-                        fn:function(args){ // # of (k,v) == sourcenodeids.length
-                            var name = args["8d41e4de-a250-11e9-973b-00224800b26d"];
-                            return 'consultation for '+name;
+                        fn:function(args, callback){
+                            var resourceId = args["8d41e4de-a250-11e9-973b-00224800b26d"];
+                            var displayName = ko.observable();
+                            self.updateDisplayName(resourceId, displayName);
+                            displayName.subscribe(function(name) {
+                                if(ko.unwrap(name)) {
+                                    callback('Consultation for '+ko.unwrap(name));
+                                }
+                            });
                         },
                         sourcenodeids: ["8d41e4de-a250-11e9-973b-00224800b26d"],
                         targetnodeid: "8d41e4ab-a250-11e9-87d1-00224800b26d"
@@ -170,6 +178,17 @@ define([
                 }
                 self.previousStep(activeStep);
             }
+
+            this.displayname = ko.observable();
+
+            this.updateDisplayName = function(resourceId, displayname) {
+                $.get(
+                    arches.urls.resource_descriptors + ko.unwrap(resourceId),
+                    function(descriptors) {
+                        displayname(descriptors.displayname);
+                    }
+                );
+            };
 
             self.activeStep.subscribe(this.updateState);
 

--- a/consultations_prj/media/js/views/components/plugins/consultation-workflow.js
+++ b/consultations_prj/media/js/views/components/plugins/consultation-workflow.js
@@ -26,14 +26,18 @@ define([
                     title: 'Assign Name',
                     name: 'setname',
                     description: 'Assign a name to your application area',
-                    component: 'views/components/workflows/new-tile-step',
-                    componentname: 'new-tile-step',
+                    component: 'views/components/workflows/get-tile-value',
+                    componentname: 'get-tile-value',
                     graphid: '8d41e49e-a250-11e9-9eab-00224800b26d',
                     nodegroupid: '8d41e4ab-a250-11e9-87d1-00224800b26d',
                     resourceid: null,
                     tileid: null,
                     parenttileid: null,
-                    icon: 'fa-tag'
+                    icon: 'fa-tag',
+                    config: {
+                        fn:function(){},
+                        sourcenodeids: ["8d41e4ba-a250-11e9-9b20-00224800b26d"]
+                    }
                 },
                 {
                     title: 'Consultation GeoJSON',

--- a/consultations_prj/media/js/views/components/plugins/consultation-workflow.js
+++ b/consultations_prj/media/js/views/components/plugins/consultation-workflow.js
@@ -36,9 +36,10 @@ define([
                     icon: 'fa-tag',
                     config: {
                         fn:function(args){ // # of (k,v) == sourcenodeids.length
-                            var name = args["8d41e4ba-a250-11e9-9b20-00224800b26d"];
-                            return ('consultation for '+name); },
-                        sourcenodeids: ["8d41e4ba-a250-11e9-9b20-00224800b26d"],
+                            var name = args["8d41e4de-a250-11e9-973b-00224800b26d"];
+                            return 'consultation for '+name;
+                        },
+                        sourcenodeids: ["8d41e4de-a250-11e9-973b-00224800b26d"],
                         targetnodeid: "8d41e4ab-a250-11e9-87d1-00224800b26d"
                     }
                 },
@@ -161,6 +162,7 @@ define([
                         self.state.resourceid = resourceId;
                         activeStep.requirements.resourceid = self.state.resourceid;
                     }
+                    activeStep.requirements.tiles = previousStep.requirements.tiles;
                     self.updateUrl();
                 } else {
                     activeStep.requirements = self.state.steps[activeStep._index] || {};

--- a/consultations_prj/media/js/views/components/workflows/get-tile-value.js
+++ b/consultations_prj/media/js/views/components/workflows/get-tile-value.js
@@ -26,6 +26,7 @@ define([
         this.namelabel = params.namelabel;
         this.applyOutputToTarget = params.applyOutputToTarget;
         this.checkBox = ko.observable(false);
+        if(params.config.checkbox) { this.checkBox(true); }
 
         if(!!params.config.sourcenodeids()) {
             this.sourceNodeIds = params.config.sourcenodeids();

--- a/consultations_prj/media/js/views/components/workflows/get-tile-value.js
+++ b/consultations_prj/media/js/views/components/workflows/get-tile-value.js
@@ -17,10 +17,13 @@ define([
         this.nameheading = params.nameheading;
         this.namelabel = params.namelabel;
         this.applyOutputToTarget = params.applyOutputToTarget;
+        this.tileMethod = params.config.fn || ko.observable();
+        this.sourceNodeIds = params.config.sourcenodeids || [];
 
-        this.workflowStepClass = ko.pureComputed(function() {
-            return self.applyOutputToTarget() ? params.class() : '';
-        }, viewModel);
+        // this.workflowStepClass = ko.pureComputed(function() {
+        //     return self.applyOutputToTarget() ? params.class() : '';
+        // }, viewModel);
+        this.workflowStepClass = params.class || ko.observable();
 
         params.tile = self.tile;
 
@@ -37,14 +40,25 @@ define([
             var targetresult;
             var targettile;
             var sourcetile;
-            var targetvals;
+            var targetvals, someData;
+            tiles = params.requirements.tiles;
+
             tiles.forEach(function(tile){
-                    if (tile.nodegroup_id === ko.unwrap(params.targetnodegroup)) {
-                        targettile = tile;
-                    } else if (tile.nodegroup_id === ko.unwrap(params.nodegroupid)) {
-                        sourcetile = tile;
+                console.log(tile);
+                self.sourceNodeIds.forEach(function(nodeid) {
+                    if (tile["data"][nodeid] != undefined) {
+                        someData = tile["data"][nodeid]();
+                        //somehow display this data via lookup
+                        //get it into the workflowstep's tile.data
                     }
-                });
+                })
+
+                // if (tile.nodegroup_id === ko.unwrap(params.targetnodegroup)) {
+                //     targettile = tile;
+                // } else if (tile.nodegroup_id === ko.unwrap(params.nodegroupid)) {
+                //     sourcetile = tile;
+                // }
+            });
             targetvals = _.map(sourcetile.data, function(v, k) {return ko.unwrap(v)})
             targetresult = targetvals[2] + ", " + targetvals[0] + " " + targetvals[1];
             targettile.data[params.targetnode()](targetresult);
@@ -52,8 +66,8 @@ define([
         };
 
         self.applyOutputToTarget.subscribe(function(val){
-            if (val && self.tiles && self.tiles.length > 0) {
-                self.updateTargetTile(self.tiles);
+            if (val && params.requirements.tiles.length > 0) {
+                self.updateTargetTile(params.requirements.tiles);
             }
         });
 
@@ -63,9 +77,7 @@ define([
                 params.resourceid(tiles[0].resourceinstance_id);
                 self.resourceId(tiles[0].resourceinstance_id);
             }
-            if (self.applyOutputToTarget()) {
-                self.updateTargetTile(tiles)
-            }
+            // self.updateTargetTile(tiles)
             if (self.completeOnSave === true) {
                 self.complete(true);
             }

--- a/consultations_prj/templates/views/components/workflows/get-tile-value.htm
+++ b/consultations_prj/templates/views/components/workflows/get-tile-value.htm
@@ -1,5 +1,6 @@
 <!-- ko if: tile() && card() && loading() == false-->
 <div class="padded-workflow-step">
+    <!-- ko if: checkBox() -->
     <div class="workflows-get-tile-value"><h4 data-bind="text: nameheading"></h4>
         <div class="checkbox">
             <label class="form-checkbox form-normal form-primary" data-bind="css: {'active': applyOutputToTarget}" style="padding-left: 25px; padding-top: 3px;">
@@ -8,6 +9,7 @@
             </label>
         </div>
     </div>
+    <!-- /ko -->
     <div data-bind="class: workflowStepClass">
         <div data-bind="component: {
             name: cardComponentLookup[card().model.component_id()].componentname,

--- a/consultations_prj/templates/views/components/workflows/get-tile-value.htm
+++ b/consultations_prj/templates/views/components/workflows/get-tile-value.htm
@@ -1,4 +1,4 @@
-<!-- ko if: tile() && card() -->
+<!-- ko if: tile() && card() && loading() == false-->
 <div class="padded-workflow-step">
     <div class="workflows-get-tile-value"><h4 data-bind="text: nameheading"></h4>
         <div class="checkbox">


### PR DESCRIPTION
alters get-tile-value workflow step significantly to expect a config object from the step params:

```Expected from params.config: 
              config: {
                 fn: function(argsObj, callback){
                          //logic
                          //callback(returnValue)
                     },
                 sourcenodeids: [], //arr of nodeids
                 targetnodeid: "1234-abcd-5678-efgh"
              }
             Note that argsObj.keys.length == sourcenodeids.length
             i.e. each tile datum is an argument you need
```

the get-tile-value viewmodel passes a callback into this custom function to set the current workflow step's tile's value.

Another change includes the addition of a `tiles` array to params.requirements which acts as a state for tiles produced by preceding workflow steps. This change is effected by a companion branch in core arches in new-tile-step and new-multi-tile-step.