### PR TITLE
Refactors workflow step state management

### DIFF
--- a/consultations_prj/media/js/views/components/plugins/consultation-workflow.js
+++ b/consultations_prj/media/js/views/components/plugins/consultation-workflow.js
@@ -136,7 +136,7 @@ define([
                 var previousStep = self.previousStep();
                 var resourceId;
                 if (previousStep) {
-                    self.state.steps[previousStep._index] = previousStep.stateProperties();
+                    self.state.steps[previousStep._index] = previousStep.getStateProperties();
                     self.state.steps[previousStep._index].complete = ko.unwrap(previousStep.complete);
                     self.state.activestep = val._index;
                     self.state.previousstep = previousStep._index;

--- a/consultations_prj/media/js/views/components/plugins/consultation-workflow.js
+++ b/consultations_prj/media/js/views/components/plugins/consultation-workflow.js
@@ -131,29 +131,6 @@ define([
 
             Workflow.apply(this, [params]);
 
-            this.updateState = function(val) {
-                var activeStep = val;
-                var previousStep = self.previousStep();
-                var resourceId;
-                if (previousStep) {
-                    self.state.steps[previousStep._index] = previousStep.getStateProperties();
-                    self.state.steps[previousStep._index].complete = ko.unwrap(previousStep.complete);
-                    self.state.activestep = val._index;
-                    self.state.previousstep = previousStep._index;
-                    if (!resourceId) {
-                        resourceId = !!previousStep.resourceid ? ko.unwrap(previousStep.resourceid) : null;
-                        self.state.resourceid = resourceId;
-                        activeStep.requirements.resourceid = self.state.resourceid;
-                    }
-                    // activeStep.requirements.tiles = previousStep.requirements.tiles;
-                    self.updateUrl();
-                } else {
-                    activeStep.requirements = self.state.steps[activeStep._index] || {};
-                    activeStep.requirements.resourceid = self.state.resourceid;
-                }
-                self.previousStep(activeStep);
-            }
-
             self.activeStep.subscribe(this.updateState);
 
             self.ready(true);

--- a/consultations_prj/media/js/views/components/plugins/site-visit.js
+++ b/consultations_prj/media/js/views/components/plugins/site-visit.js
@@ -16,7 +16,7 @@ define([
                     title: 'Site Visit Details - Related Consultation',
                     name: 'sitevisitdetailsrelatedconsultation',
                     description: '',
-                    component: 'views/components/workflows/new-tile-step',
+                    component: 'views/components/workflows/select-resource-step',
                     componentname: 'select-resource-step',
                     graphid: '8d41e49e-a250-11e9-9eab-00224800b26d',
                     // nodegroupid: '1cff60de-a251-11e9-a296-00224800b26d', //Visit Date

--- a/consultations_prj/media/js/views/components/workflows/consultation-dates-step.js
+++ b/consultations_prj/media/js/views/components/workflows/consultation-dates-step.js
@@ -8,18 +8,22 @@ define([
     function viewModel(params) {
 
         NewTileStep.apply(this, [params]);
-        if (!params.resourceid() && params.requirements){
-            params.resourceid(params.requirements.resourceid);
-            params.tileid(params.requirements.tileid);
+        var self = this;
+
+        if (!params.resourceid()) {
+            params.resourceid(params.workflow.state.resourceid);
+        }
+        if (params.workflow.state.steps[params._index]) {
+            params.tileid(params.workflow.state.steps[params._index].tileid);
         }
 
-        var self = this;
-        
-        self.requirements = params.requirements;
+        var url = arches.urls.api_card + (ko.unwrap(params.resourceid) || ko.unwrap(params.graphid));
+
+
         params.tile = self.tile;
         this.relatedAppAreaTile = ko.observable();
 
-        params.stateProperties = function(){
+        params.getStateProperties = function(){
             return {
                 resourceid: ko.unwrap(params.resourceid),
                 tile: !!(params.tile) ? koMapping.toJS(params.tile().data) : undefined,
@@ -98,6 +102,8 @@ define([
                 params.tileid(tile.tileid);
                 self.resourceId(tile.resourceinstance_id);
             }
+            self.setStateProperties();
+            params.workflow.updateUrl();
             if (self.completeOnSave === true) { self.complete(true); }
         };
     };

--- a/consultations_prj/media/js/views/components/workflows/file-template.js
+++ b/consultations_prj/media/js/views/components/workflows/file-template.js
@@ -19,7 +19,7 @@ define([
         self.requirements = params.requirements;
         params.tile = self.tile;
 
-        params.stateProperties = function(){
+        params.getStateProperties = function(){
                 return {
                     resourceid: ko.unwrap(params.resourceid),
                     tile: !!(params.tile) ? koMapping.toJS(params.tile().data) : undefined,

--- a/consultations_prj/media/js/views/components/workflows/get-tile-value.js
+++ b/consultations_prj/media/js/views/components/workflows/get-tile-value.js
@@ -26,7 +26,7 @@ define([
 
         params.tile = self.tile;
 
-        params.stateProperties = function(){
+        params.getStateProperties = function(){
             return {
                 resourceid: ko.unwrap(params.resourceid),
                 tile: !!(ko.unwrap(params.tile)) ? koMapping.toJS(params.tile().data) : undefined,

--- a/consultations_prj/media/js/views/components/workflows/get-tile-value.js
+++ b/consultations_prj/media/js/views/components/workflows/get-tile-value.js
@@ -11,10 +11,13 @@ define([
         NewTileStep.apply(this, [params]);
 
         params.applyOutputToTarget = ko.observable(true);
-        if (!params.resourceid() && params.requirements){
-            params.resourceid(params.requirements.resourceid);
-            params.tileid(params.requirements.tileid);
+        if (!params.resourceid()) {
+            params.resourceid(params.workflow.state.resourceid);
         }
+        if (params.workflow.state.steps[params._index]) {
+            params.tileid(params.workflow.state.steps[params._index].tileid);
+        }
+
         this.nameheading = params.nameheading;
         this.namelabel = params.namelabel;
         this.applyOutputToTarget = params.applyOutputToTarget;

--- a/consultations_prj/media/js/views/components/workflows/hide-card-step.js
+++ b/consultations_prj/media/js/views/components/workflows/hide-card-step.js
@@ -8,9 +8,11 @@ define([
 ], function(_, $, arches, ko, koMapping, NewTileStep) {
     function viewModel(params) {
         NewTileStep.apply(this, [params]);
-        if (!params.resourceid() && params.requirements){
-            params.resourceid(params.requirements.resourceid);
-            params.tileid(params.requirements.tileid);
+        if (!params.resourceid()) {
+            params.resourceid(params.workflow.state.resourceid);
+        }
+        if (params.workflow.state.steps[params._index]) {
+            params.tileid(params.workflow.state.steps[params._index].tileid);
         }
 
         this.workflowStepClass = ko.unwrap(params.class());

--- a/consultations_prj/media/js/views/components/workflows/hide-card-step.js
+++ b/consultations_prj/media/js/views/components/workflows/hide-card-step.js
@@ -14,7 +14,7 @@ define([
         }
 
         this.workflowStepClass = ko.unwrap(params.class());
-        params.stateProperties = function(){
+        params.getStateProperties = function(){
             return {
                 resourceid: ko.unwrap(params.resourceid),
                 tile: !!(ko.unwrap(params.tile)) ? koMapping.toJS(params.tile().data) : undefined,

--- a/consultations_prj/media/js/views/components/workflows/photo-gallery-step.js
+++ b/consultations_prj/media/js/views/components/workflows/photo-gallery-step.js
@@ -10,7 +10,7 @@ define([
         var self = this;
         params.completeOnSave = false;
         NewTileStep.apply(this, [params]);
-    };
+    }
 
     return ko.components.register('photo-gallery-step', {
         viewModel: viewModel,

--- a/consultations_prj/media/js/views/components/workflows/select-resource-step.js
+++ b/consultations_prj/media/js/views/components/workflows/select-resource-step.js
@@ -29,7 +29,7 @@ define([
         this.card.subscribe(function(val){ if(ko.unwrap(val) != undefined) { this.loading(false); } }, this);
         this.tile.subscribe(function(val){ if(ko.unwrap(val) != undefined) { this.loading(false); } }, this);
         params.tile = self.tile;
-        params.stateProperties = function() {
+        params.getStateProperties = function() {
             return {
                 resourceid: ko.unwrap(params.resourceid),
                 tile: !!(ko.unwrap(params.tile)) ? koMapping.toJS(params.tile().data) : undefined,

--- a/consultations_prj/media/js/views/components/workflows/select-resource-step.js
+++ b/consultations_prj/media/js/views/components/workflows/select-resource-step.js
@@ -26,8 +26,10 @@ define([
         this.nameheading = params.nameheading;
         this.namelabel = params.namelabel;
         this.resValue.subscribe(function(val){
-            self.tile().resourceinstance_id = ko.unwrap(val);
-            params.resourceid(ko.unwrap(val)); //redundant with setting params.requirements.resourceid?
+            if (ko.unwrap(self.tile)) {
+                self.tile().resourceinstance_id = ko.unwrap(val);
+            }
+            params.resourceid(ko.unwrap(val));
         }, this);
 
         this.card.subscribe(function(val){ if(ko.unwrap(val) != undefined) { this.loading(false); } }, this);
@@ -38,7 +40,7 @@ define([
             params.workflow.state.steps[params._index] = params.getStateProperties();
             this.disableResourceSelection(true);
         };
-    };
+    }
 
     ko.components.register('select-resource-step', {
         viewModel: viewModel,

--- a/consultations_prj/media/js/views/components/workflows/select-resource-step.js
+++ b/consultations_prj/media/js/views/components/workflows/select-resource-step.js
@@ -9,19 +9,23 @@ define([
     function viewModel(params) {
         var self = this;
         NewTileStep.apply(this, [params]);
-        params.applyOutputToTarget = ko.observable(true);
-        if (!params.resourceid() && params.requirements){
-            params.resourceid(params.requirements.resourceid);
-            params.tileid(params.requirements.tileid);
+        this.resValue = ko.observable();
+        if (!params.resourceid()) {
+            params.resourceid(params.workflow.state.resourceid);
         }
-        self.loading(true);
+        if (params.workflow.state.steps[params._index]) {
+            params.tileid(params.workflow.state.steps[params._index].tileid);
+        }
+        this.disableResourceSelection = ko.observable(false);
+        if (params.workflow.state.resourceid) {
+            this.resValue(params.workflow.state.resourceid);
+            this.disableResourceSelection(true);
+        }
+        this.loading(true);
         this.graphid = params.graphid();
         this.nameheading = params.nameheading;
         this.namelabel = params.namelabel;
-        this.resValue = ko.observable();
-        this.applyOutputToTarget = params.applyOutputToTarget;
         this.resValue.subscribe(function(val){
-            params.requirements.resourceid = ko.unwrap(val);
             self.tile().resourceinstance_id = ko.unwrap(val);
             params.resourceid(ko.unwrap(val)); //redundant with setting params.requirements.resourceid?
         }, this);
@@ -29,22 +33,11 @@ define([
         this.card.subscribe(function(val){ if(ko.unwrap(val) != undefined) { this.loading(false); } }, this);
         this.tile.subscribe(function(val){ if(ko.unwrap(val) != undefined) { this.loading(false); } }, this);
         params.tile = self.tile;
-        params.getStateProperties = function() {
-            return {
-                resourceid: ko.unwrap(params.resourceid),
-                tile: !!(ko.unwrap(params.tile)) ? koMapping.toJS(params.tile().data) : undefined,
-                tileid: !!(ko.unwrap(params.tile)) ? ko.unwrap(params.tile().tileid): undefined,
-            }
-        };
 
-        self.onSaveSuccess = function(tiles) {
-            self.tiles = tiles;
-            if (self.tiles.length > 0) {
-                params.resourceid(tiles[0].resourceinstance_id);
-                self.resourceId(tiles[0].resourceinstance_id);
-            }
-            if (self.completeOnSave === true) { self.complete(true); }
-        }
+        this.setStateProperties = function(){
+            params.workflow.state.steps[params._index] = params.getStateProperties();
+            this.disableResourceSelection(true);
+        };
     };
 
     ko.components.register('select-resource-step', {

--- a/consultations_prj/templates/views/components/workflows/select-resource-step.htm
+++ b/consultations_prj/templates/views/components/workflows/select-resource-step.htm
@@ -9,7 +9,8 @@
                     form: $data,
                     value: resValue,
                     pageVm: $root,
-                    graphid: graphid
+                    graphid: graphid,
+                    disabled: disableResourceSelection
                 }
             } --><!-- /ko -->
         </div>
@@ -31,4 +32,3 @@
     </div>
     <!-- /ko -->
 </div>
-


### PR DESCRIPTION
Refactors workflow step state management so that steps do not use the `requirements` object, but get values directly from the workflow.state object when the step is initialized. Also, updates state when a tile is saved - not just when steps are changed. re archesproject/arches#5101