### PR TITLE
Update for active consultation status class 

### DIFF
--- a/consultations_prj/templates/views/components/plugins/active-consultations.htm
+++ b/consultations_prj/templates/views/components/plugins/active-consultations.htm
@@ -27,7 +27,11 @@
                 <div class="card-grid-item">
                     <div class="panel mar-no">
                         <!-- Function Name -->
-                        <div class="active-cons-header">
+                        <div class="active-cons-header" data-bind="css: {
+                                                      'status-ok': ($parent.getTargetDays($data['Target Date']) > 7),
+                                                      'status-warning': ($parent.getTargetDays($data['Target Date']) <=7 &&
+                                                                         $parent.getTargetDays($data['Target Date']) >= 1),
+                                                      'status-late': ($parent.getTargetDays($data['Target Date']) < 1)}">
                             <div class="active-cons-header-title" data-bind="text: Name"></div>
                             <!-- <div data-bind="text: $data['Consultation Type']"></div> -->
                         </div>
@@ -63,11 +67,8 @@
                             <!-- /ko -->
                         </div>
 
-                        <div class="active-cons-stubs" data-bind="css: {
-                                                      'status-ok': ($parent.getTargetDays($data['Target Date']) > 7),
-                                                      'status-warning': ($parent.getTargetDays($data['Target Date']) <=7 &&
-                                                                         $parent.getTargetDays($data['Target Date']) >= 1),
-                                                      'status-late': ($parent.getTargetDays($data['Target Date']) < 1)}">                            <div class="active-cons-stub-left">
+                        <div class="active-cons-stubs">
+                            <div class="active-cons-stub-left">
                                 <div class="active-cons-stub-val" data-bind="text: $data['Target Date'] || 'Date not entered'"></div>
                                 <div class="active-cons-stub-label" data-bind="">Target Date</div>
                             </div>


### PR DESCRIPTION
This update will append the consultation status class to the 'active-cons-header' instead of 'active-cons-stubs'