### PR TITLE
247 active consultations url

### DIFF
--- a/consultations_prj/media/js/views/components/plugins/active-consultations.js
+++ b/consultations_prj/media/js/views/components/plugins/active-consultations.js
@@ -10,7 +10,7 @@ define([
     return ko.components.register('active-consultations',  {
         viewModel: function(params) {
             var self = this;
-            this.resourceEditorURL = arches.urls.resource_editor;
+            this.resourceEditorURL = '/consultations' + arches.urls.resource_editor;
             this.moment = moment;
             this.layout = ko.observable('grid');
             this.setLayout = function(layout){ self.layout(layout); };

--- a/consultations_prj/pkg/extensions/search/search-results-consultations/search-results-consultations.htm
+++ b/consultations_prj/pkg/extensions/search/search-results-consultations/search-results-consultations.htm
@@ -2,10 +2,20 @@
 {% load template_tags %}
 {% load i18n %}
 
-<div id="search-results-list" data-bind="foreach: results, visible: true" style="display: none;">
+{% if user.username == 'anonymous' %}
+    <div id="search-results-list" data-bind="foreach: results, visible: true" style="display: none;">
 
-    <div class="search-result" data-bind="event: { mouseover: mouseoverInstance, mouseout: mouseoverInstance('')}, css: {'selected': selected()}">
-        <a class="" href="" data-bind="click: $parent.viewReport.bind($parent)"><span data-bind="text: displayname"></span></a>
+        <div class="search-result" data-bind="event: { mouseover: mouseoverInstance, mouseout: mouseoverInstance('')}, css: {'selected': selected()}">
+            <a class="" href="" data-bind="click: $parent.viewReport.bind($parent)"><span data-bind="text: displayname"></span></a>
+        </div>
+
     </div>
+{% else %}
+    <div id="search-results-list" data-bind="foreach: results, visible: true" style="display: none;">
 
-</div>
+        <div class="search-result" data-bind="event: { mouseover: mouseoverInstance, mouseout: mouseoverInstance('')}, css: {'selected': selected()}">
+            <a class="" href="" data-bind="click: $parent.editResource.bind($parent)"><span data-bind="text: displayname"></span></a>
+        </div>
+
+    </div>
+{% endif %}

--- a/consultations_prj/pkg/extensions/search/search-results-consultations/search-results-consultations.js
+++ b/consultations_prj/pkg/extensions/search/search-results-consultations/search-results-consultations.js
@@ -135,7 +135,7 @@ function($, _, BaseFilter, bootstrap, arches, select2, ko, koMapping, viewdata) 
             },
 
             editResource: function(resourceinstance){
-                window.open(arches.urls.resource_editor + resourceinstance.resourceinstanceid);
+                window.open('/consultations' + arches.urls.resource_editor + resourceinstance.resourceinstanceid);
             },
 
             zoomToFeature: function(evt){

--- a/consultations_prj/templates/views/components/search/search-results-consultations.htm
+++ b/consultations_prj/templates/views/components/search/search-results-consultations.htm
@@ -2,10 +2,20 @@
 {% load template_tags %}
 {% load i18n %}
 
-<div id="search-results-list" data-bind="foreach: results, visible: true" style="display: none;">
+{% if user.username == 'anonymous' %}
+    <div id="search-results-list" data-bind="foreach: results, visible: true" style="display: none;">
 
-    <div class="search-result" data-bind="event: { mouseover: mouseoverInstance, mouseout: mouseoverInstance('')}, css: {'selected': selected()}">
-        <a class="" href="" data-bind="click: $parent.viewReport.bind($parent)"><span data-bind="text: displayname"></span></a>
+        <div class="search-result" data-bind="event: { mouseover: mouseoverInstance, mouseout: mouseoverInstance('')}, css: {'selected': selected()}">
+            <a class="" href="" data-bind="click: $parent.viewReport.bind($parent)"><span data-bind="text: displayname"></span></a>
+        </div>
+
     </div>
+{% else %}
+    <div id="search-results-list" data-bind="foreach: results, visible: true" style="display: none;">
 
-</div>
+        <div class="search-result" data-bind="event: { mouseover: mouseoverInstance, mouseout: mouseoverInstance('')}, css: {'selected': selected()}">
+            <a class="" href="" data-bind="click: $parent.editResource.bind($parent)"><span data-bind="text: displayname"></span></a>
+        </div>
+
+    </div>
+{% endif %}


### PR DESCRIPTION
Directs users from the active consultations to the resource editor at the consultations endpoint. Also points search results to the editor rather than report when logged in. re #247 