### PR TITLE
Remove the Related Search option from consultations

### DIFF
--- a/consultations_prj/templates/views/search_consultations.htm
+++ b/consultations_prj/templates/views/search_consultations.htm
@@ -62,7 +62,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
             <!-- Title Block -->
             <div class="search-toolbar" style="">
                 <div class="search-type-btn-panel" data-bind="foreach: {data: sharedStateObject.filtersList, as: 'filter'}">
-                    <!-- ko if: filter.type === 'filter' && filter.enabled -->
+                    <!-- ko if: filter.type === 'filter' && filter.enabled && filter.name !== "Related" -->
                     {% if user|can_read_resource_instance %}
                     <button class="search-type-btn relative" style="" data-bind="css: {'active': $parent.sharedStateObject.selectedTab() === filter.componentname}, click: function(){$parent.sharedStateObject.selectedTab(filter.componentname)}">
                         <i data-bind="css: filter.icon"></i>


### PR DESCRIPTION
Remove the related search option from consultations