### PR TITLE
Remove the gap between consultation dates in workflow, #552

### DIFF
--- a/arches_her/media/css/project.css
+++ b/arches_her/media/css/project.css
@@ -722,7 +722,7 @@ li.workflow-main-nav-item a {
 }
 
 div.hide-completion-date > div > div > div > div > form > div > div:nth-child(3) {
-    visibility: hidden;
+    display: none;
 }
 
 .ep-toolbar.cons {


### PR DESCRIPTION
Update the css to hide an element and remove the gap, #552 
Resolve an issue with consultations dates step (unnecessary gap between dates)