### PR TITLE
Add a default collapsed menu, esri#142

### DIFF
--- a/arches_her/templates/index.htm
+++ b/arches_her/templates/index.htm
@@ -56,13 +56,21 @@ The data-spy and data-target are part of the built-in Bootstrap scrollspy functi
     <!--=== Header ===-->
     <nav class="cons-splash-nav navbar" role="navigation">
         <div class="nav-container">
-            <div class="navbar-brand-disco">
-                <div class="navbar-brand-disco-icon-container" style="">
-                    <img class="navbar-brand-disco-icon" src="{% static 'img/landing/arches_logo_dark.png' %}" style="" alt="Arches Logo">
-                </div>
-                <div class="application-name">
-                    <h2>{{app_title}}</h2>
-                    <!-- <span>Data Integration for Science and Conservation</span> -->
+            <div class="menu-container page-scroll">
+                <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-ex1-collapse">
+                    <span class="sr-only">Toggle navigation</span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                </button>
+                <div class="navbar-brand-disco">
+                    <div class="navbar-brand-disco-icon-container" style="">
+                        <img class="navbar-brand-disco-icon" src="{% static 'img/landing/arches_logo_dark.png' %}" style="" alt="Arches Logo">
+                    </div>
+                    <div class="application-name">
+                        <h2>{{app_title}}</h2>
+                        <!-- <span>Data Integration for Science and Conservation</span> -->
+                    </div>
                 </div>
             </div>
 


### PR DESCRIPTION
Show a collapsed menu bar when the windows size is reduced, archesproject/arches-esri-add-in#142
Fix the issue that the menu disappears entirely when the windows size is small.