### PR TITLE
BNG function and datatype updates for 5.2.x (#620)

### DIFF
--- a/arches_her/datatypes/bngcentrepoint.py
+++ b/arches_her/datatypes/bngcentrepoint.py
@@ -19,7 +19,7 @@ details = {
 
 
 class BNGCentreDataType(BaseDataType):
-    def validate(self, value, row_number=None, source=None, node=None, nodeid=None):
+    def validate(self, value, row_number=None, source=None, node=None, nodeid=None, strict=False):
 
         errors = []
         gridSquareArray = [

--- a/arches_her/functions/bngpoint_to_geojson_function.py
+++ b/arches_her/functions/bngpoint_to_geojson_function.py
@@ -202,7 +202,7 @@ class BNGPointToGeoJSON(BaseFunction):
 
             cursor = connection.cursor()
             sql = """
-                    REFRESH MATERIALIZED VIEW mv_geojson_geoms;
+                    SELECT * FROM refresh_geojson_geometries();
                 """
             cursor.execute(sql)  #
 

--- a/arches_her/pkg/extensions/datatypes/bngcenterpoint/bngcentrepoint.py
+++ b/arches_her/pkg/extensions/datatypes/bngcenterpoint/bngcentrepoint.py
@@ -19,7 +19,7 @@ details = {
 
 
 class BNGCentreDataType(BaseDataType):
-    def validate(self, value, row_number=None, source=None, node=None, nodeid=None):
+    def validate(self, value, row_number=None, source=None, node=None, nodeid=None, strict=False):
 
         errors = []
         gridSquareArray = [

--- a/arches_her/pkg/extensions/functions/bngpoint-to-geojson-function/bngpoint_to_geojson_function.py
+++ b/arches_her/pkg/extensions/functions/bngpoint-to-geojson-function/bngpoint_to_geojson_function.py
@@ -202,7 +202,7 @@ class BNGPointToGeoJSON(BaseFunction):
 
             cursor = connection.cursor()
             sql = """
-                    REFRESH MATERIALIZED VIEW mv_geojson_geoms;
+                    SELECT * FROM refresh_geojson_geometries();
                 """
             cursor.execute(sql)  #
 


### PR DESCRIPTION
Updating the BNG datatype and BNG to GeoJSON function to work with Arches stable/5.2.x as per issue #620 

Added strict=false to validate in the BNG datatype
Changed SQL in BNG to GeoJSON function to SELECT * FROM refresh_geojson_geometries();
Manual testing with these changes applied - all resource models in arches-her that use the BNG datatype checked

