### PR TITLE
adds port back for vscode debugging

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       ports:
       #change this to avoid conflicts with other projects
         - 8002:8000
+        - 5679:5678
       # depends_on:
       #   - db_aher
       #   - elasticsearch_aher


### PR DESCRIPTION
vscode debug port was scrubbed from docker; this adds it back.  