### PR TITLE
Update date format for consultation name, #680

### DIFF
--- a/arches_her/media/js/views/components/workflows/consultation/consultation-dates-step.js
+++ b/arches_her/media/js/views/components/workflows/consultation/consultation-dates-step.js
@@ -82,9 +82,9 @@ define([
             var DefaultTargetDateLeadTime = 22;
             if(val) {
                 self.tile().data[self.logDateNodeId].subscribe(function(val) {
-                    logDateVal = new Date(val);
+                    logDateVal = new Date(`${val} 00:00`);
                     if (logDateVal != 'Invalid Date') {
-                        self.concatName(`Consultation for ${self.displayName()} on ${logDateVal.toLocaleDateString()}`);
+                        self.concatName(`Consultation for ${self.displayName()} on ${self.formatDate(logDateVal)}`);
                         targetDateVal = self.addDays(logDateVal, DefaultTargetDateLeadTime);
                         self.tile().data[self.targetDateNodeId](targetDateVal);
                     }


### PR DESCRIPTION
Fix the date format in the consultation name for consistency, #680
To `yyyy-mm-dd`
To avoid confusion `mm/dd/yyyy` or `dd/mm/yyyy`