### PR TITLE
pep 517 is causing problems for the install process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ COPY ./arches ${ARCHES_ROOT}
 # From here, run commands from ARCHES_ROOT
 WORKDIR ${ARCHES_ROOT}
 
-RUN pip install -e . && pip install -r arches/install/requirements_dev.txt
+RUN pip install -e . --no-use-pep517 && pip install -r arches/install/requirements_dev.txt
 
 COPY /arches_her/docker/entrypoint.sh ${WEB_ROOT}/entrypoint.sh
 RUN chmod -R 700 ${WEB_ROOT}/entrypoint.sh &&\


### PR DESCRIPTION
There's a problem with editable mode in the current arches her container build.  Skirting pep 517 is the only way we've found to workaround the problem.  There's probably a larger fix that'll need to be made to make us compatible with pep 517.