### PR TITLE
Fix to Artefact Geospatial Coordinates

### DIFF
--- a/arches_her/pkg/graphs/resource_models/Artefact.json
+++ b/arches_her/pkg/graphs/resource_models/Artefact.json
@@ -294,25 +294,6 @@
                 },
                 {
                     "active": true,
-                    "cardid": "5043cede-31df-11ec-9f77-a87eeabdefba",
-                    "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
-                    "config": null,
-                    "constraints": [],
-                    "cssclass": null,
-                    "description": null,
-                    "graph_id": "343cc20c-2c5a-11e8-90fa-0242ac120005",
-                    "helpenabled": false,
-                    "helptext": null,
-                    "helptitle": null,
-                    "instructions": null,
-                    "is_editable": true,
-                    "name": "Geospatial Coordinates",
-                    "nodegroup_id": "f7ccc8b9-f447-11eb-9cb1-a87eeabdefba",
-                    "sortorder": null,
-                    "visible": true
-                },
-                {
-                    "active": true,
                     "cardid": "507099c0-381d-11e8-ac76-dca90488358a",
                     "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
                     "config": null,
@@ -703,7 +684,7 @@
                         "selectSource": "",
                         "selectSourceLayer": "",
                         "selectText": "",
-                        "zoom": "9"
+                        "zoom": 8.563321631643019
                     },
                     "constraints": [],
                     "cssclass": null,
@@ -6510,7 +6491,7 @@
                         "overlayOpacity": null,
                         "pitch": null,
                         "rerender": true,
-                        "zoom": "9"
+                        "zoom": 8.563321631643019
                     },
                     "id": "f7cd1aed-f447-11eb-a1eb-a87eeabdefba",
                     "label": "Geospatial Coordinates",
@@ -11001,12 +10982,6 @@
                     "cardinality": "1",
                     "legacygroupid": null,
                     "nodegroupid": "f7ccc8ae-f447-11eb-8d86-a87eeabdefba",
-                    "parentnodegroup_id": "f7cc629f-f447-11eb-b2d3-a87eeabdefba"
-                },
-                {
-                    "cardinality": "1",
-                    "legacygroupid": null,
-                    "nodegroupid": "f7ccc8b9-f447-11eb-9cb1-a87eeabdefba",
                     "parentnodegroup_id": "f7cc629f-f447-11eb-b2d3-a87eeabdefba"
                 },
                 {
@@ -17965,12 +17940,12 @@
                     "exportable": false,
                     "fieldname": null,
                     "graph_id": "343cc20c-2c5a-11e8-90fa-0242ac120005",
-                    "is_collector": true,
+                    "is_collector": false,
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
                     "name": "Geospatial Coordinates",
-                    "nodegroup_id": "f7ccc8b9-f447-11eb-9cb1-a87eeabdefba",
+                    "nodegroup_id": "f7cc629f-f447-11eb-b2d3-a87eeabdefba",
                     "nodeid": "f7ccc8b9-f447-11eb-9cb1-a87eeabdefba",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E94_Space_Primitive",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P168_place_is_defined_by",
@@ -19105,5 +19080,11 @@
             "template_id": "50000000-0000-0000-0000-000000000002",
             "version": ""
         }
-    ]
+    ],
+    "metadata": {
+        "db": "PostgreSQL 12.2 (Debian 12.2-1.pgdg100+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 8.3.0-6) 8.3.0, 64-bit",
+        "git hash": "fatal: ambiguous argument '%ai'': unknown revision or path not in the working tree.",
+        "os": "Windows",
+        "os version": "10"
+    }
 }


### PR DESCRIPTION
Geospatial Coordinates node had been placed in separate card. placed in same card as feature shape.