### PR TITLE
removed incorrect dateFormat property in EDTF nodes

### DIFF
--- a/arches_her/pkg/graphs/resource_models/Maritime Vessel.json
+++ b/arches_her/pkg/graphs/resource_models/Maritime Vessel.json
@@ -12456,7 +12456,6 @@
             "nodes": [
                 {
                     "config": {
-                        "dateFormat": "YYYY-MM-DD",
                         "fuzzy_day_padding": 1,
                         "fuzzy_month_padding": 1,
                         "fuzzy_season_padding": 12,
@@ -21469,7 +21468,6 @@
                 },
                 {
                     "config": {
-                        "dateFormat": "YYYY-MM-DD",
                         "fuzzy_day_padding": 1,
                         "fuzzy_month_padding": 1,
                         "fuzzy_season_padding": 12,


### PR DESCRIPTION
Addresses #791 

Removed two instances where EDTF nodes in Maritime Vessel resource model graph had a dateFormat property.