### PR TITLE
Display alert when required node has no data, re #899

### DIFF
--- a/arches_her/media/js/views/components/workflows/communication-workflow/communication-select-resource.js
+++ b/arches_her/media/js/views/components/workflows/communication-workflow/communication-select-resource.js
@@ -3,8 +3,8 @@ define([
     'knockout',
     'uuid',
     'arches',
-    'knockout-mapping'
-], function(_, ko, uuid, arches, koMapping) {
+    'viewmodels/alert'
+], function(_, ko, uuid, arches, AlertViewModel) {
     function viewModel(params) {
         var self = this;
         this.resValue = ko.observable().extend({ deferred: true });
@@ -96,6 +96,12 @@ define([
             }).then(function(response) {
                 if (response.ok) {
                     return response.json();
+                } else {
+                    response.json().then(result => {
+                        params.form.error(new Error("Missing Required Value"));
+                        params.pageVm.alert(new AlertViewModel('ep-alert-red', result.title, result.message));
+                        return;
+                    })
                 }
             });
         };
@@ -103,13 +109,15 @@ define([
         params.form.save = function() {
             self.saveTile(communicationTileData(), communicationNodegroupId, self.resourceid(), self.tileid())
                 .then(function(data) {
-                    self.resourceid(data.resourceinstance_id);
-                    self.tileid(data.tileid);
-                    self.disableResourceSelection(true);
-                    params.form.complete(true);
-                    params.form.savedData({
-                        resourceid: self.resourceid(), ...self.updatedValue()
-                    });
+                    if (data?.resourceinstance_id) {
+                        self.resourceid(data.resourceinstance_id);
+                        self.tileid(data.tileid);
+                        self.disableResourceSelection(true);
+                        params.form.complete(true);
+                        params.form.savedData({
+                            resourceid: self.resourceid(), ...self.updatedValue()
+                        });
+                    }
                 })
         };
     }

--- a/arches_her/templates/views/components/workflows/communication-workflow/communication-select-resource.htm
+++ b/arches_her/templates/views/components/workflows/communication-workflow/communication-select-resource.htm
@@ -64,7 +64,7 @@
                 },
             },
             config: {
-                'label': 'Type',
+                'label': 'Type*',
                 'options': [{
                     'id': '0f466b8b-a347-439f-9b61-bee9811ccbf0',
                     'text': 'Email',


### PR DESCRIPTION
Fixes bug causing Communication workflow to stall on first step by dropping the loading spinner and displaying an alert when required node has no data, re #899