### PR TITLE
Remove unused map sources, re #921

### DIFF
--- a/arches_her/pkg/preliminary_sql/select_sources.sql
+++ b/arches_her/pkg/preliminary_sql/select_sources.sql
@@ -3,16 +3,4 @@ INSERT INTO map_sources(name, source)
         "data": "/geojson?nodeid=1909956f-3a3b-11eb-ae99-f875a44e0e11&include_geojson_link=true",
         "type": "geojson"
     }');
-
-INSERT INTO map_sources(name, source)
-    VALUES ('select-heritage-area', '{
-        "data": "/geojson?nodeid=64be56e3-3ee5-11eb-b1f0-f875a44e0e11&include_geojson_link=true",
-        "type": "geojson"
-    }');
-
-INSERT INTO map_sources(name, source)
-    VALUES ('select-heritage-asset', '{
-        "data": "/geojson?nodeid=ca063178-28cf-11eb-be6d-f875a44e0e11&include_geojson_link=true",
-        "type": "geojson"
-    }');
     


### PR DESCRIPTION
This is a stop-gap measure to remove unused layers that result in calls to the geojson endpoint each time the map component is loaded. This change will prevent making 2 of the 3 requests referred to in #921. A complete solution would be to also replace the `select-application-area` with a vector tile source, eliminating all of the unnecessary requests.

The changes in this PR will only be effective when the package is loaded into a new database. 

To apply this to an existing HER project without reloading the package, you can run:
```
delete from map_sources where name in ('select-heritage-asset','select-heritage-area');
```
