### PR TITLE
930 HTML report - Parent Asset fix

### DIFF
--- a/arches_her/templates/html_export/076f9381-7b00-11e9-8d6b-80000b44d1d9.htm
+++ b/arches_her/templates/html_export/076f9381-7b00-11e9-8d6b-80000b44d1d9.htm
@@ -365,15 +365,11 @@
          {% if resource_data|has_key:"Parent Asset" %}
          <section>
             <div class="container">
-                <h3>Parent Assets</h3>
+                <h3>Parent Asset</h3>
                <div class="row">
                   <div class="column">
                     <div class="keeptogether">
-                        <ul>
-                            {% for parAsset in resource_data|val_from_key:"Parent Asset" %}
-                                <li>{{parAsset|val_from_key:"@display_value"}}</li>
-                            {% endfor %}
-                        </ul>
+                        {{resource_data|val_from_key:"Parent Asset"|val_from_key:"@display_value"}}
                      </div>
                   </div>
                </div>


### PR DESCRIPTION
The HTML report issue #930 has been fixed so the Parent Asset now displayed in the HTML export report.