### PR TITLE
HTML report - Associated Resources fix

### DIFF
--- a/arches_her/templates/html_export/076f9381-7b00-11e9-8d6b-80000b44d1d9.htm
+++ b/arches_her/templates/html_export/076f9381-7b00-11e9-8d6b-80000b44d1d9.htm
@@ -369,11 +369,7 @@
                <div class="row">
                   <div class="column">
                     <div class="keeptogether">
-                        <ul>
-                            {% for parAsset in resource_data|val_from_key:"Parent Asset" %}
-                                <li>{{parAsset|val_from_key:"@display_value"}}</li>
-                            {% endfor %}
-                        </ul>
+                        {{resource_data|val_from_key:"Parent Asset"|val_from_key:"@display_value"}}
                      </div>
                   </div>
                </div>
@@ -416,18 +412,14 @@
 
 
          {# Associated Activities #}
-         {% if resource_data|has_key:"Associated_Activities" %}
+         {% if resource_data|has_key:"Associated Activities" %}
          <section>
             <div class="container">
                <h3>Associated Activities</h3>
                <div class="row">
                   <div class="column">
                      <div class="keeptogether">
-                        <ul>
-                           {% for assocAct in resource_data|val_from_key:"Associated_Activities" %}
-                           <li>{{ assocAct|val_from_key:"@display_value" }}</li>
-                           {% endfor %}
-                        </ul>
+                        {{ resource_data|val_from_key:"Associated Activities"|val_from_key:"@display_value" }}
                      </div>
                   </div>
                </div>

--- a/arches_her/templates/html_export/42ce82f6-83bf-11ea-b1e8-f875a44e0e11.htm
+++ b/arches_her/templates/html_export/42ce82f6-83bf-11ea-b1e8-f875a44e0e11.htm
@@ -200,15 +200,11 @@
         {% if resource_data|has_key:"Associated Application Area" %}
         <section>
            <div class="container">
-              <h3>Associated Application Area</h3>
+              <h3>Associated Application Areas</h3>
               <div class="row">
                  <div class="column">
                     <div class="keeptogether">
-                       <ul>
-                          {% for assocApp in resource_data|val_from_key:"Associated Application Area" %}
-                          <li>{{ assocApp|val_from_key:"@display_value" }}</li>
-                          {% endfor %}
-                          </ul>
+                       {{ resource_data|val_from_key:"Associated Application Area" |val_from_key:"@display_value" }}
                     </div>
                  </div>
               </div>
@@ -225,11 +221,7 @@
               <div class="row">
                  <div class="column">
                     <div class="keeptogether">
-                       <ul>
-                          {% for assocCon in resource_data|val_from_key:"Associated Consultations" %}
-                          <li>{{ assocCon|val_from_key:"@display_value" }}</li>
-                          {% endfor %}
-                          </ul>
+                       {{ resource_data|val_from_key:"Associated Consultations"|val_from_key:"@display_value" }}
                     </div>
                  </div>
               </div>
@@ -246,11 +238,7 @@
               <div class="row">
                  <div class="column">
                     <div class="keeptogether">
-                       <ul>
-                       {% for assocAAAVA in resource_data|val_from_key:"Associated Heritage Assets, Areas and Artefacts" %}
-                       <li>{{ assocAAAVA|val_from_key:"@display_value" }}</li>
-                       {% endfor %}
-                       </ul>
+                       {{ resource_data|val_from_key:"Associated Heritage Assets, Areas and Artefacts"|val_from_key:"@display_value" }}
                     </div>
                  </div>
               </div>
@@ -267,11 +255,7 @@
               <div class="row">
                  <div class="column">
                     <div class="keeptogether">
-                       <ul>
-                          {% for assocAct in resource_data|val_from_key:"Associated Activities" %}
-                          <li>{{ assocAct|val_from_key:"@display_value" }}</li>
-                          {% endfor %}
-                          </ul>
+                       {{ resource_data|val_from_key:"Associated Activities"|val_from_key:"@display_value" }}
                     </div>
                  </div>
               </div>

--- a/arches_her/templates/html_export/49bac32e-5464-11e9-a6e2-000d3ab1e588.htm
+++ b/arches_her/templates/html_export/49bac32e-5464-11e9-a6e2-000d3ab1e588.htm
@@ -438,11 +438,7 @@
             <div class="row">
                 <div class="column">
                     <div class="keeptogether">
-                    <ul>
-                        {% for assocAct in resource_data|val_from_key:"Associated Activities" %}
-                        <li>{{ assocAct|val_from_key:"@display_value" }}</li>
-                        {% endfor %}
-                    </ul>
+                       {{ resource_data|val_from_key:"Associated Activities"|val_from_key:"@display_value" }}
                     </div>
                 </div>
             </div>

--- a/arches_her/templates/html_export/8d41e49e-a250-11e9-9eab-00224800b26d.htm
+++ b/arches_her/templates/html_export/8d41e49e-a250-11e9-9eab-00224800b26d.htm
@@ -347,11 +347,7 @@
                <div class="row">
                   <div class="column">
                      <div class="keeptogether">
-                        <ul>
-                        {% for assocCons in resource_data|val_from_key:"Associated Consultations" %}
-                        <li>{{ assocCons|val_from_key:"@display_value" }}</li>
-                        {% endfor %}
-                        </ul>
+                        {{ resource_data|val_from_key:"Associated Consultations"|val_from_key:"@display_value" }}
                      </div>
                   </div>
                </div>
@@ -368,11 +364,7 @@
                <div class="row">
                   <div class="column">
                      <div class="keeptogether">
-                        <ul>
-                        {% for assocAAAVA in resource_data|val_from_key:"Related Heritage Assets and Areas" %}
-                        <li>{{ assocAAAVA|val_from_key:"@display_value" }}</li>
-                        {% endfor %}
-                        </ul>
+                        {{ resource_data|val_from_key:"Related Heritage Assets and Areas"|val_from_key:"@display_value" }}
                      </div>
                   </div>
                </div>
@@ -389,11 +381,7 @@
                <div class="row">
                   <div class="column">
                      <div class="keeptogether">
-                        <ul>
-                        {% for assocAct in resource_data|val_from_key:"Associated Activities" %}
-                        <li>{{ assocAct|val_from_key:"@display_value" }}</li>
-                        {% endfor %}
-                        </ul>
+                        {{ resource_data|val_from_key:"Associated Activities"|val_from_key:"@display_value" }}
                      </div>
                   </div>
                </div>

--- a/arches_her/templates/html_export/979aaf0b-7042-11ea-9674-287fcf6a5e72.htm
+++ b/arches_her/templates/html_export/979aaf0b-7042-11ea-9674-287fcf6a5e72.htm
@@ -395,11 +395,7 @@
                <div class="row">
                   <div class="column">
                      <div class="keeptogether">
-                        <ul>
-                           {% for assocAct in resource_data|val_from_key:"Associated Activities" %}
-                           <li>{{ assocAct|val_from_key:"@display_value" }}</li>
-                           {% endfor %}
-                           </ul>
+                        {{ resource_data|val_from_key:"Associated Activities"|val_from_key:"@display_value" }}
                      </div>
                   </div>
                </div>

--- a/arches_her/templates/html_export/b8032b00-594d-11e9-9cf0-18cf5eb368c4.htm
+++ b/arches_her/templates/html_export/b8032b00-594d-11e9-9cf0-18cf5eb368c4.htm
@@ -374,11 +374,7 @@
                <div class="row">
                   <div class="column">
                      <div class="keeptogether">
-                        <ul>
-                           {% for assocAct in resource_data|val_from_key:"Associated Activities" %}
-                           <li>{{ assocAct|val_from_key:"@display_value"  }}</li>
-                           {% endfor %}
-                           </ul>
+                        {{ resource_data|val_from_key:"Associated Activities"|val_from_key:"@display_value"  }}
                      </div>
                   </div>
                </div>

--- a/arches_her/templates/html_export/b9e0701e-5463-11e9-b5f5-000d3ab1e588.htm
+++ b/arches_her/templates/html_export/b9e0701e-5463-11e9-b5f5-000d3ab1e588.htm
@@ -12,7 +12,7 @@
 
 <body>
     <header>
-        {% include 'html_export/custom_header.htm' %} 
+        {% include 'html_export/custom_header.htm' %}
         <h1>Activities</h1>
     </header>
     <main>
@@ -139,7 +139,7 @@
         </section>
         <hr/>
         {% endif %}
-        
+
         {# Location Data #}
         {% if resource_data|has_key:"Location Data" %}
         <section>
@@ -215,7 +215,7 @@
         </section>
         <hr/>
         {% endif %}
-       
+
         {# Descriptions #}
         {% if resource_data|has_key:"Activity Descriptions" %}
         <section>
@@ -263,7 +263,7 @@
         </section>
         <hr/>
         {% endif %}
-      
+
         {# Bibliographic Source Citation #}
         {% if resource_data|has_key:"Bibliographic Source Citation" %}
         <section>
@@ -304,11 +304,7 @@
                 <div class="row">
                     <div class="column">
                         <div class="keeptogether">
-                            <ul>
-                                {% for assocAAAVA in resource_data|val_from_key:"Associated Heritage Assets and Areas" %}
-                                <li>{{ assocAAAVA|val_from_key:"@display_value" }}</li>
-                                {% endfor %}
-                            </ul>
+                            {{ resource_data|val_from_key:"Associated Heritage Assets and Areas"|val_from_key:"@display_value" }}
                         </div>
                     </div>
                 </div>
@@ -325,11 +321,7 @@
                 <div class="row">
                     <div class="column">
                         <div class="keeptogether">
-                            <ul>
-                                {% for activity in resource_data|val_from_key:"Parent_Activity" %}
-                                <li>{{ activity|val_from_key:"@display_value" }}</li>
-                                {% endfor %}
-                            </ul>
+                            {{ resource_data|val_from_key:"Parent_Activity"|val_from_key:"@display_value" }}
                         </div>
                     </div>
                 </div>
@@ -346,11 +338,7 @@
                 <div class="row">
                     <div class="column">
                         <div class="keeptogether">
-                            <ul>
-                                {% for activity in resource_data|val_from_key:"Associated Activities" %}
-                                <li>{{ activity|val_from_key:"@display_value" }}</li>
-                                {% endfor %}
-                            </ul>
+                            {{ resource_data|val_from_key:"Associated Activities"|val_from_key:"@display_value" }}
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Pull after #933 

The HTML report issue #929  has been fixed so the Associated Resources now displayed in the HTML export report.