### PR TITLE
Prevent error in consultations final step when consultation has no geom

### DIFF
--- a/arches_her/media/js/views/components/workflows/consultation/consultations-final-step.js
+++ b/arches_her/media/js/views/components/workflows/consultation/consultations-final-step.js
@@ -12,6 +12,7 @@ define([
 
         this.resourceLoading = ko.observable(true);
         this.relatedResourceLoading = ko.observable(true);
+        this.geometry = false;
 
         this.resourceData.subscribe(function(val){
             this.displayName = val['displayname'] || 'Unnamed';
@@ -46,8 +47,13 @@ define([
 
             var geojsonStr = this.getResourceValue(val.resource, ['Consultation Area', 'Geometry', 'Geospatial Coordinates', '@value']);
             if (geojsonStr) {
-                var geojson = JSON.parse(geojsonStr.replaceAll("'", '"'));
-                this.prepareMap(geojson, 'app-area-map-data');
+                try {
+                    var geojson = JSON.parse(geojsonStr.replaceAll("'", '"'));
+                    this.prepareMap(geojson, 'app-area-map-data');
+                    this.geometry = true;
+                } catch(e) {
+                    //pass
+                }
             };
             this.resourceLoading(false);
             if (!self.relatedResourceLoading()) {

--- a/arches_her/templates/views/components/workflows/consultation/consultations-final-step.htm
+++ b/arches_her/templates/views/components/workflows/consultation/consultations-final-step.htm
@@ -16,6 +16,7 @@
     <div class="her-final-step-section">
         <h5 class="summary-value">{% trans 'Consultation Area' %}</h5>
         <div class="final-step-section-block-item">
+            <!--ko if: geometry -->
             <div class="map-container">
                 <div class="map" data-bind="component: {
                     name: 'arches-map',
@@ -23,6 +24,7 @@
                 }">
                 </div>
             </div>
+            <!--/ko-->
             
             <!-- Related Map information -->
             <div class="final-step-section-block-item">


### PR DESCRIPTION
Prevents an error in consultations final step when consultation has no geometry. Also, does not show map if there is no geometry to present.