### PR TITLE
hide xref section of names scene when used in consultation report

### DIFF
--- a/arches_her/media/js/views/components/reports/scenes/name.js
+++ b/arches_her/media/js/views/components/reports/scenes/name.js
@@ -33,6 +33,7 @@ define(['underscore', 'knockout', 'arches', 'utils/report','bindings/datatable']
             self.delete = params.deleteTile || self.deleteTile;
             self.add = params.addTile || self.addNewTile;
             self.names = ko.observableArray();
+            self.hideCrossReferences = ko.observable(params.hideCrossReferences ?? false);
             self.crossReferences = ko.observableArray();
             self.systemReferenceNumbers = ko.observable();
             self.parentData = ko.observable();
@@ -100,15 +101,20 @@ define(['underscore', 'knockout', 'arches', 'utils/report','bindings/datatable']
                     self.crossReferences(xrefData.map(x => {
                         const name = self.getNodeValue(x,{
                             testPaths: [
+                                ['external cross reference', '@display_value'],
                                 ['external cross reference']
                             ]});
                         const description = self.getNodeValue(x, {
                             testPaths: [
+                                ['external cross reference notes', 'external cross reference description', '@display_value'],
                                 ['external cross reference notes', 'external cross reference description']
                             ]});
                         
                         const source = self.getNodeValue(x, {
-                            testPaths: [['external cross reference source']]
+                            testPaths: [
+                                ['external cross reference source', '@display_value'],
+                                ['external cross reference source']
+                            ]
                         });
 
                         const urlJson = self.getNodeValue(x, {

--- a/arches_her/templates/views/components/reports/consultation.htm
+++ b/arches_her/templates/views/components/reports/consultation.htm
@@ -33,7 +33,8 @@
                     params: {
                         data: resource,
                         cards: nameCards,
-                        dataConfig: nameDataConfig
+                        dataConfig: nameDataConfig,
+                        hideCrossReferences: true
                     }
                 }"></div>
                 <div data-bind="component: {

--- a/arches_her/templates/views/components/reports/scenes/name.htm
+++ b/arches_her/templates/views/components/reports/scenes/name.htm
@@ -57,7 +57,8 @@
 <!-- /ko -->
 
 <!-- External Reference -->
-<div class="aher-report-section" data-bind="visible: !!dataConfig.xref" >
+<!-- ko ifnot: hideCrossReferences() -->
+<div data-bind="visible: !!dataConfig.xref" class="aher-report-section">
     <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.crossReferences)}, css: {'fa-angle-double-right': visible.crossReferences(), 'fa-angle-double-up': !visible.crossReferences()}" class="fa toggle"></i> {% trans "External Cross References" %}</h2>
     <a data-bind="{if: cards.externalCrossReferences, click: function(){addNewTile(cards.externalCrossReferences)}}" class="aher-report-a"><i class="fa fa-mail-reply"></i> {% trans "Add Reference" %}</a>
 
@@ -85,7 +86,7 @@
                             <tr>
                                 <td data-bind="text: name"></td>
                                 <td data-bind="text: source"></td>
-                                <td data-bind="text: description"></td>
+                                <td data-bind="html: description"></td>
                                 <td>
                                     <!-- ko with: url -->
                                     <!-- ko if: url -->
@@ -112,6 +113,7 @@
         <!-- /ko -->
     </div>
 </div>
+<!-- /ko -->
 
 <!-- System Reference Numbers section -->
 <div class="aher-report-section">


### PR DESCRIPTION
Enabled it so that the xref section in names scene can be hidden by passing in a new value to the viewmodel via params. USed this in the Consultation report template