### PR TITLE
Make the digital object filename a clickable link

### DIFF
--- a/arches_her/media/js/views/components/reports/digital-object.js
+++ b/arches_her/media/js/views/components/reports/digital-object.js
@@ -36,6 +36,17 @@ define([
             self.cards = {};
             self.copyrightCards = {};
 
+            self.visible = {
+                files: ko.observable(true),
+            }
+
+            self.createTableConfig = function(col) {
+                return {
+                    ...self.defaultTableConfig,
+                    columns: Array(col).fill(null)
+                };
+            }
+
             if(params.report.cards){
                 const cards = params.report.cards;
                 
@@ -56,18 +67,25 @@ define([
                 }
             }
 
+            self.files = ko.observableArray();
+            
+            const fileDetailsNode = self.getRawNodeValue(self.resource(), 'file content', 'file', 'file_details');
+            const fileNode = self.getRawNodeValue(self.resource(), 'file content', 'file');
+            if(Array.isArray(fileDetailsNode)){
+                const tileid = self.getTileId(fileNode);
+                self.files(fileDetailsNode.map(node => {
+                    const name = self.getNodeValue(node, 'name');
+                    const link = self.getNodeValue(node, 'url');
+                    return {name, link, tileid};
+                }));
+            };
+
             self.fileData = ko.observable({
                 sections:
                     [
                         {
-                            title: 'File Details',
+                            title: 'Details',
                             data: [{
-                                key: 'File',
-                                value: self.getFileName(self.getRawNodeValue(self.resource(), 'file content', 'file')),
-                                href: self.getNodeValue(self.resource(), 'file content', 'file'),
-                                type: 'href',
-                                card: self.cards?.file
-                            },{
                                 key: 'Format',
                                 value: self.getNodeValue(self.resource(), 'file format type'),
                                 type: 'kv',

--- a/arches_her/media/js/views/components/reports/digital-object.js
+++ b/arches_her/media/js/views/components/reports/digital-object.js
@@ -64,7 +64,8 @@ define([
                             data: [{
                                 key: 'File',
                                 value: self.getFileName(self.getRawNodeValue(self.resource(), 'file content', 'file')),
-                                type: 'kv',
+                                href: self.getNodeValue(self.resource(), 'file content', 'file'),
+                                type: 'href',
                                 card: self.cards?.file
                             },{
                                 key: 'Format',

--- a/arches_her/templates/views/components/reports/digital-object.htm
+++ b/arches_her/templates/views/components/reports/digital-object.htm
@@ -59,6 +59,43 @@
             </div>
             <!-- File Tab -->
             <div class="aher-report-page" data-bind="if: activeSection() === 'file'">
+                <div class="aher-report-section">
+                    <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.files)}, css: {'fa-angle-double-right': visible.files(), 'fa-angle-double-up': !visible.files()}"  class="fa toggle"></i> {% trans "Files" %}</h2>
+                    <a data-bind="{if: cards['file'], click: function(){addNewTile(cards['file'])}}" class="aher-report-a">
+                        <i class="fa fa-mail-reply"></i>
+                        <span data-bind="if: cards.file.tiles().length">{% trans "Edit Files" %}</span>
+                        <span data-bind="ifnot: cards.file.tiles().length">{% trans "Add Files" %}</span>
+                    </a>
+
+                    <!-- Collapsible content -->
+                    <div data-bind="visible: visible.files" class="aher-report-collapsible-container pad-lft">
+
+                        <!-- ko ifnot: files().length -->
+                        <div class="aher-nodata-note">{% trans "No files" %}</div>
+                        <!-- /ko -->
+
+                        <!-- ko if: files().length -->
+                        <div class="aher-report-subsection">
+                            <div class="firstchild-container">
+                                <div class="aher-table">
+                                    <table class="table table-striped" cellspacing="0" width="100%">
+                                        <thead>
+                                            <tr>
+                                                <th>{% trans "Filename" %}</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody data-bind="dataTablesForEach: { data: files, dataTableOptions: createTableConfig(1)}">
+                                            <tr>
+                                                <td><a class="aher-table-link" data-bind="text: name, attr: {href: link}" target="_blank"></a></td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
+                        </div>
+                        <!-- /ko -->
+                    </div>
+                </div>
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/default',
                     params: {

--- a/arches_her/templates/views/components/reports/scenes/keyvalue.htm
+++ b/arches_her/templates/views/components/reports/scenes/keyvalue.htm
@@ -36,7 +36,7 @@
 <!-- /ko --> 
 
 <!-- ko if: item.type == 'href'-->
-<div class="aher-block-value"><a data-bind="text: item.value, attr: { href: item.href }"></a></div>
+<div class="aher-block-value"><a data-bind="text: item.value, attr: { href: item.href, target: '_blank' }"></a></div>
 <!-- /ko -->  
 
 <!-- ko if: item.type == 'timespan' -->


### PR DESCRIPTION
In the Digital Object resource report, make the file under the File Details tab clickable as a link to download the file. #917 