### PR TITLE
Fixes bug when handling empty xref url node in consultation report

### DIFF
--- a/arches_her/media/js/views/components/reports/consultation.js
+++ b/arches_her/media/js/views/components/reports/consultation.js
@@ -170,8 +170,12 @@ define([
                     const note = self.getNodeValue(node, 'external cross reference notes', 'external cross reference description');
                     const noteDescType = self.getNodeValue(node, 'external cross reference notes', 'external cross reference description type');
                     const urlNodeValue = self.getRawNodeValue(node, 'url');
-                    const url = urlNodeValue.url;
-                    const urlLabel = urlNodeValue.url_label ? urlNodeValue.url_label : urlNodeValue.url;
+                    let url = undefined;
+                    let urlLabel = undefined;
+                    if(urlNodeValue){
+                        url = urlNodeValue.url;
+                        urlLabel = urlNodeValue.url_label ? urlNodeValue.url_label : urlNodeValue.url;
+                    }
                     const tileid = self.getTileId(node);
                     return {reference, source, note, noteDescType, url, urlLabel, tileid};
                 }));


### PR DESCRIPTION
handles the url node in xref tiles being empty

fixes #955