### PR TITLE
fixes component table con phase and evidence in classification scene

### DIFF
--- a/arches_her/media/js/views/components/reports/scenes/classifications.js
+++ b/arches_her/media/js/views/components/reports/scenes/classifications.js
@@ -353,11 +353,21 @@ define(['underscore', 'knockout', 'arches', 'utils/report','bindings/datatable']
                 const componentsNode = self.getRawNodeValue(params.data(), 'components');
                 if(Array.isArray(componentsNode)) {
                     self.components(componentsNode.map(x => {
-                        const constructionPhase = self.getNodeValue(x, 'associated area phase');
+                        const constructionPhase = self.getNodeValue(x, { 
+                            testPaths:[
+                                ['associated area phase'],
+                                ['associated asset construction phase'],
+                            ]}
+                        );
                         const component = self.getNodeValue(x, 'component', 'component type');
                         const material = self.getNodeValue(x, 'component', 'component material');
                         const technique = self.getNodeValue(x, 'construction technique');
-                        const evidence = self.getNodeValue(x, 'component attribute assignment', 'evidence type');
+                        const evidence = self.getNodeValue(x,  { 
+                            testPaths:[
+                                ['component attribute assignment', 'evidence type'],
+                                ['component attribute assignment', 'component evidence type'],
+                            ]}
+                        );
                         const tileid = self.getTileId(x);
 
                         return { 


### PR DESCRIPTION
adds testpaths for heritage asset con phase and evidence in component table of classifications scene

fixes #962 