### PR TITLE
fixes assessment tab for heritage asset report

### DIFF
--- a/arches_her/media/js/views/components/reports/heritage-asset.js
+++ b/arches_her/media/js/views/components/reports/heritage-asset.js
@@ -58,6 +58,7 @@ define([
             self.descriptionCards = {};
             self.classificationCards = {};
             self.scientificDateCards = {};
+            self.assessmentCards = {};
             self.imagesCards = {};
             self.locationCards = {};
             self.protectionCards = {};


### PR DESCRIPTION
fixes the assessment tab not loading on the report page of Heritage Asset

fixes 963