### PR TITLE
Update graphs with alias changes and remove cruft

### DIFF
--- a/arches_her/pkg/graphs/resource_models/Consultation.json
+++ b/arches_her/pkg/graphs/resource_models/Consultation.json
@@ -15477,11 +15477,5 @@
             "template_id": "465443ea-0e01-4895-a9cf-5144b02213da",
             "version": ""
         }
-    ],
-    "metadata": {
-        "db": "PostgreSQL 12.2 (Debian 12.2-1.pgdg100+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 8.3.0-6) 8.3.0, 64-bit",
-        "git hash": "fatal: ambiguous argument '%ai'': unknown revision or path not in the working tree.",
-        "os": "Windows",
-        "os version": "10"
-    }
+    ]
 }

--- a/arches_her/pkg/graphs/resource_models/Historic Aircraft.json
+++ b/arches_her/pkg/graphs/resource_models/Historic Aircraft.json
@@ -13260,7 +13260,7 @@
                     "sortorder": 0
                 },
                 {
-                    "alias": "final_place_of_destination",
+                    "alias": "place_of_destination",
                     "config": null,
                     "datatype": "semantic",
                     "description": "",
@@ -13279,7 +13279,7 @@
                     "sortorder": 0
                 },
                 {
-                    "alias": "final_place_of_destination_name",
+                    "alias": "place_of_destination_name",
                     "config": {
                         "rdmCollection": "c3869409-0ab4-4327-9841-be7ec1da7810"
                     },
@@ -13300,7 +13300,7 @@
                     "sortorder": 0
                 },
                 {
-                    "alias": "final_place_of_destination_name_type",
+                    "alias": "place_of_destination_name_type",
                     "config": {
                         "rdmCollection": "3e545767-c46c-4fe7-8754-c24528ba0842"
                     },
@@ -13321,7 +13321,7 @@
                     "sortorder": 0
                 },
                 {
-                    "alias": "final_place_of_destination_name_use_type",
+                    "alias": "place_of_destination_name_use_type",
                     "config": {
                         "rdmCollection": "1e4df896-992b-475e-bb5a-78817d3066d7"
                     },
@@ -13342,7 +13342,7 @@
                     "sortorder": 0
                 },
                 {
-                    "alias": "final_place_of_destination_name_currency",
+                    "alias": "place_of_destination_name_currency",
                     "config": {
                         "rdmCollection": "a346ee99-67f6-44cd-87f7-b564ce32cdf3"
                     },
@@ -13363,7 +13363,7 @@
                     "sortorder": 0
                 },
                 {
-                    "alias": "final_place_of_destination_name_metatype",
+                    "alias": "place_of_destination_name_metatype",
                     "config": {
                         "rdmCollection": "1e63c514-eb9d-48d3-94b5-35e060e5f368"
                     },
@@ -13384,7 +13384,7 @@
                     "sortorder": 0
                 },
                 {
-                    "alias": "final_place_of_destination_name_use_metatype",
+                    "alias": "place_of_destination_name_use_metatype",
                     "config": {
                         "rdmCollection": "1e63c514-eb9d-48d3-94b5-35e060e5f368"
                     },
@@ -13405,7 +13405,7 @@
                     "sortorder": 0
                 },
                 {
-                    "alias": "final_place_of_destination_name_currency_metatype",
+                    "alias": "place_of_destination_name_currency_metatype",
                     "config": {
                         "rdmCollection": "1e63c514-eb9d-48d3-94b5-35e060e5f368"
                     },
@@ -13426,7 +13426,7 @@
                     "sortorder": 0
                 },
                 {
-                    "alias": "final_destination_placenames",
+                    "alias": "destination_placenames",
                     "config": null,
                     "datatype": "semantic",
                     "description": "The name of a resource.Applies to Heritage Resource, Heritage Resource Group, Activity, and Historical Event.  Actors receive their 'names' from the Appellation branch.",
@@ -13603,7 +13603,7 @@
                     "sortorder": 0
                 },
                 {
-                    "alias": "last_cargo_metatype",
+                    "alias": "cargo_metatype",
                     "config": {
                         "rdmCollection": "1e63c514-eb9d-48d3-94b5-35e060e5f368"
                     },
@@ -13988,7 +13988,7 @@
                     "sortorder": 0
                 },
                 {
-                    "alias": "last_cargo",
+                    "alias": "cargo",
                     "config": null,
                     "datatype": "semantic",
                     "description": "Represents a single node in a graph",
@@ -14007,7 +14007,7 @@
                     "sortorder": 0
                 },
                 {
-                    "alias": "last_cargo_type",
+                    "alias": "cargo_type",
                     "config": {
                         "rdmCollection": "3ce20cb0-6069-4c19-a845-5c67ada11413"
                     },
@@ -14028,7 +14028,7 @@
                     "sortorder": 0
                 },
                 {
-                    "alias": "final_place_of_departure",
+                    "alias": "place_of_departure",
                     "config": null,
                     "datatype": "semantic",
                     "description": null,
@@ -14121,7 +14121,7 @@
                     "sortorder": 0
                 },
                 {
-                    "alias": "last_flight_type",
+                    "alias": "flight_type",
                     "config": {
                         "rdmCollection": "f8ff8b9b-d6ae-4b98-9cd9-6d065b7fa220"
                     },
@@ -14142,7 +14142,7 @@
                     "sortorder": 0
                 },
                 {
-                    "alias": "last_flight_date_qualifier_metatype",
+                    "alias": "flight_date_qualifier_metatype",
                     "config": {
                         "rdmCollection": "1e63c514-eb9d-48d3-94b5-35e060e5f368"
                     },
@@ -18862,7 +18862,7 @@
                     "sortorder": 0
                 },
                 {
-                    "alias": "last_flight_timespan",
+                    "alias": "flight_timespan",
                     "config": null,
                     "datatype": "semantic",
                     "description": "",
@@ -18881,7 +18881,7 @@
                     "sortorder": 0
                 },
                 {
-                    "alias": "last_flight_date_qualifier",
+                    "alias": "flight_date_qualifier",
                     "config": {
                         "rdmCollection": "366686d6-deb0-4245-81a3-f94d791a388c"
                     },
@@ -19309,7 +19309,7 @@
                     "sortorder": 0
                 },
                 {
-                    "alias": "last_flight_metatype",
+                    "alias": "flight_metatype",
                     "config": {
                         "rdmCollection": "1e63c514-eb9d-48d3-94b5-35e060e5f368"
                     },
@@ -19382,7 +19382,7 @@
                     "sortorder": 0
                 },
                 {
-                    "alias": "final_departure_placenames",
+                    "alias": "departure_placenames",
                     "config": null,
                     "datatype": "semantic",
                     "description": "The name of a resource.Applies to Heritage Resource, Heritage Resource Group, Activity, and Historical Event.  Actors receive their 'names' from the Appellation branch.",
@@ -19401,7 +19401,7 @@
                     "sortorder": 0
                 },
                 {
-                    "alias": "final_place_of_departure_name_use_type",
+                    "alias": "place_of_departure_name_use_type",
                     "config": {
                         "rdmCollection": "1e4df896-992b-475e-bb5a-78817d3066d7"
                     },
@@ -19422,7 +19422,7 @@
                     "sortorder": 0
                 },
                 {
-                    "alias": "final_place_of_departure_name_currency",
+                    "alias": "place_of_departure_name_currency",
                     "config": {
                         "rdmCollection": "a346ee99-67f6-44cd-87f7-b564ce32cdf3"
                     },
@@ -19443,7 +19443,7 @@
                     "sortorder": 0
                 },
                 {
-                    "alias": "final_place_of_departure_name",
+                    "alias": "place_of_departure_name",
                     "config": {
                         "rdmCollection": "c3869409-0ab4-4327-9841-be7ec1da7810"
                     },
@@ -19464,7 +19464,7 @@
                     "sortorder": 0
                 },
                 {
-                    "alias": "final_place_of_departure_name_metatype",
+                    "alias": "place_of_departure_name_metatype",
                     "config": {
                         "rdmCollection": "1e63c514-eb9d-48d3-94b5-35e060e5f368"
                     },
@@ -19485,7 +19485,7 @@
                     "sortorder": 0
                 },
                 {
-                    "alias": "final_place_of_departure_name_use_metatype",
+                    "alias": "place_of_departure_name_use_metatype",
                     "config": {
                         "rdmCollection": "1e63c514-eb9d-48d3-94b5-35e060e5f368"
                     },
@@ -19506,7 +19506,7 @@
                     "sortorder": 0
                 },
                 {
-                    "alias": "final_place_of_departure_name_currency_metatype",
+                    "alias": "place_of_departure_name_currency_metatype",
                     "config": {
                         "rdmCollection": "1e63c514-eb9d-48d3-94b5-35e060e5f368"
                     },
@@ -19527,7 +19527,7 @@
                     "sortorder": 0
                 },
                 {
-                    "alias": "final_place_of_departure_name_type",
+                    "alias": "place_of_departure_name_type",
                     "config": {
                         "rdmCollection": "3e545767-c46c-4fe7-8754-c24528ba0842"
                     },
@@ -20876,7 +20876,7 @@
                     "sortorder": 0
                 },
                 {
-                    "alias": "crash_descriptions",
+                    "alias": "flight_descriptions",
                     "config": null,
                     "datatype": "semantic",
                     "description": "",
@@ -20895,7 +20895,7 @@
                     "sortorder": 0
                 },
                 {
-                    "alias": "last_flight_description",
+                    "alias": "flight_description",
                     "config": null,
                     "datatype": "string",
                     "description": null,
@@ -20914,7 +20914,7 @@
                     "sortorder": 0
                 },
                 {
-                    "alias": "last_flight_description_type",
+                    "alias": "flight_description_type",
                     "config": {
                         "rdmCollection": "0ff39ed3-cc95-4c60-9321-6d4e65fb1f2d"
                     },
@@ -20935,7 +20935,7 @@
                     "sortorder": 0
                 },
                 {
-                    "alias": "last_flight_description_metatype",
+                    "alias": "flight_description_metatype",
                     "config": {
                         "rdmCollection": "1e63c514-eb9d-48d3-94b5-35e060e5f368"
                     },
@@ -20956,7 +20956,7 @@
                     "sortorder": 0
                 },
                 {
-                    "alias": "crash_description_language",
+                    "alias": "flight_description_language",
                     "config": {
                         "rdmCollection": "daacadea-1454-4cf4-8b14-9ade8069f4d7"
                     },
@@ -20977,7 +20977,7 @@
                     "sortorder": 0
                 },
                 {
-                    "alias": "crash_description_language_metatype",
+                    "alias": "flight_description_language_metatype",
                     "config": {
                         "rdmCollection": "1e63c514-eb9d-48d3-94b5-35e060e5f368"
                     },
@@ -21778,11 +21778,5 @@
             "template_id": "655f86f0-643a-4df4-be8b-9e9030d2ff94",
             "version": ""
         }
-    ],
-    "metadata": {
-        "db": "PostgreSQL 12.2 (Debian 12.2-1.pgdg100+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 8.3.0-6) 8.3.0, 64-bit",
-        "git hash": "fatal: ambiguous argument '%ai'': unknown revision or path not in the working tree.",
-        "os": "Windows",
-        "os version": "10"
-    }
+    ]
 }


### PR DESCRIPTION
Updates the Aircraft resource model with aliases that correspond to recent changes in node names.