### PR TITLE
1044 - Change Default Message For Associated Consultations

### DIFF
--- a/arches_her/media/css/report_templates.css
+++ b/arches_her/media/css/report_templates.css
@@ -34,7 +34,7 @@
     background: #fff;
 }
 
-.scroll-y footer {
+.scroll-y footer, .aher-table-aria-describedby {
     display: none !important;
 }
 

--- a/arches_her/media/js/views/components/reports/activity.js
+++ b/arches_her/media/js/views/components/reports/activity.js
@@ -66,7 +66,8 @@ define([
                 archive: 'associated archive objects',
                 files: 'digital files',
                 assets: 'associated monuments and areas',
-                actors: undefined
+                actors: undefined,
+                resourceinstanceid: ko.unwrap(self.reportMetadata)?.resourceinstanceid
             }
 
             self.cards = {};

--- a/arches_her/media/js/views/components/reports/area.js
+++ b/arches_her/media/js/views/components/reports/area.js
@@ -55,7 +55,8 @@ define([
 
             self.resourceDataConfig = {
                 files: 'digital file(s)',
-                actors: undefined
+                actors: undefined,
+                resourceinstanceid: ko.unwrap(self.reportMetadata)?.resourceinstanceid
             };
 
             self.locationDataConfig = {

--- a/arches_her/media/js/views/components/reports/consultation.js
+++ b/arches_her/media/js/views/components/reports/consultation.js
@@ -59,7 +59,8 @@ define([
                 assets: 'related monuments and areas',
                 files: 'file(s)',
                 relatedApplicationArea: 'consultation area',
-                actors: undefined
+                actors: undefined,
+                resourceinstanceid: ko.unwrap(self.reportMetadata)?.resourceinstanceid
             };
 
             self.nameCards = {};

--- a/arches_her/media/js/views/components/reports/historic-aircraft.js
+++ b/arches_her/media/js/views/components/reports/historic-aircraft.js
@@ -57,7 +57,8 @@ define([
 
             self.resourceDataConfig = {
                 files: 'digital file(s)',
-                actors: undefined
+                actors: undefined,
+                resourceinstanceid: ko.unwrap(self.reportMetadata)?.resourceinstanceid
             }
 
             self.nameCards = {};

--- a/arches_her/media/js/views/components/reports/maritime-vessel.js
+++ b/arches_her/media/js/views/components/reports/maritime-vessel.js
@@ -67,7 +67,8 @@ define([
 
             self.resourceDataConfig = {
                 files: 'digital file(s)',
-                actors: undefined
+                actors: undefined,
+                resourceinstanceid: ko.unwrap(self.reportMetadata)?.resourceinstanceid
             }
 
             self.nameCards = {};

--- a/arches_her/media/js/views/components/reports/monument.js
+++ b/arches_her/media/js/views/components/reports/monument.js
@@ -28,6 +28,7 @@ define([
                 {id: 'resources', title: 'Associated Resources'},
                 {id: 'json', title: 'JSON'},
             ];
+
             self.reportMetadata = ko.observable(params.report?.report_json);
             self.resource = ko.observable(self.reportMetadata()?.resource);
             self.displayname = ko.observable(ko.unwrap(self.reportMetadata)?.displayname);
@@ -52,7 +53,8 @@ define([
             self.resourceDataConfig = {
                 activities: 'associated activities',
                 files: 'digital file(s)',
-                actors: undefined
+                actors: undefined,
+                resourceinstanceid: ko.unwrap(self.reportMetadata)?.resourceinstanceid
             }
 
             self.nameCards = {};

--- a/arches_her/media/js/views/components/reports/person.js
+++ b/arches_her/media/js/views/components/reports/person.js
@@ -81,7 +81,8 @@ define([
             self.resourceDataConfig = {
                 files: 'digital file(s)',
                 archive: undefined,
-                actors: undefined
+                actors: undefined,
+                resourceinstanceid: ko.unwrap(self.reportMetadata)?.resourceinstanceid
             };
             self.nameCards = {};
             self.descriptionCards = {};

--- a/arches_her/media/js/views/components/reports/scenes/resources.js
+++ b/arches_her/media/js/views/components/reports/scenes/resources.js
@@ -9,7 +9,6 @@ define(['underscore', 'knockout', 'arches', 'utils/report', 'bindings/datatable'
                 ...self.defaultTableConfig,
                 paging: true,
                 searching: true,
-                scrollY: "250px",
                 columns: Array(2).fill(null)
             };
 
@@ -19,7 +18,6 @@ define(['underscore', 'knockout', 'arches', 'utils/report', 'bindings/datatable'
                 ...self.defaultTableConfig,
                 paging: true,
                 searching: true,
-                scrollY: "250px",
                 columns: Array(4).fill(null)
             };
 
@@ -29,7 +27,6 @@ define(['underscore', 'knockout', 'arches', 'utils/report', 'bindings/datatable'
                 ...self.defaultTableConfig,
                 paging: true,
                 searching: true,
-                scrollY: "250px",
                 columns: Array(3).fill(null)
             };
 
@@ -53,11 +50,11 @@ define(['underscore', 'knockout', 'arches', 'utils/report', 'bindings/datatable'
             self.add = params.addTile || self.addNewTile;
             self.activities = ko.observableArray();
             self.consultations = ko.observableArray();
+            self.consultations_message = ko.observable(null);
             self.files = ko.observableArray();
             self.archive = ko.observableArray();
             self.actors = ko.observableArray();
             self.assets = ko.observableArray();
-            self.assets_rob = ko.observableArray();
             self.translation = ko.observableArray();
             self.applicationArea = ko.observableArray();
             self.period = ko.observableArray();
@@ -96,6 +93,45 @@ define(['underscore', 'knockout', 'arches', 'utils/report', 'bindings/datatable'
                         return { consultation, resourceUrl, tileid };
                     }));
                 }
+
+                const userAvailableConsulationCards = () => {
+                        return $.ajax({
+                            url: arches.urls.api_card + self.dataConfig.resourceinstanceid,
+                            context: this,
+                        }).done(function(response) {
+                            return response
+                        }).fail(function(){
+                            return false
+                        }
+                        )
+                    }
+
+
+                if(self.dataConfig.resourceinstanceid){
+                    userAvailableConsulationCards().then(function(cards_response){
+                        if(cards_response !== false){
+                            var card_names = []
+                            for(card in cards_response.cards){
+                                card_names.push(cards_response.cards[card].name)
+                            }
+                            if(card_names.includes("Associated Consultations")) {
+                                self.consultations_message('No consultations for this resource');
+                            }
+                            else{
+                                self.consultations_message('You do not have permission to see this information');
+                            }
+                        }
+                        else{
+                            self.consultations_message('There was an issue checking for associated consultations.');
+                        }
+                        })
+                }
+                else{
+                    self.consultations_message('There was an issue checking for associated consultations.');
+                }
+
+
+
 
 
                 const associatedArchiveNode = self.getRawNodeValue(params.data(), self.dataConfig.archive);
@@ -209,10 +245,10 @@ define(['underscore', 'knockout', 'arches', 'utils/report', 'bindings/datatable'
 
                 const translationNode = self.getRawNodeValue(params.data(), self.dataConfig.translation, 'instance_details');
                 if (Array.isArray(translationNode)) {
-                    const tileid = self.getTileId(self.getRawNodeValue(params.data(), self.dataConfig.translation));
                     self.translation(translationNode.map(x => {
                         const resource = self.getNodeValue(x);
                         const resourceLink = self.getResourceLink(self.getRawNodeValue(x));
+                        const tileid = self.getTileId(x);
                         return { resource, resourceLink, tileid };
                     }));
                 }

--- a/arches_her/templates/views/components/reports/scenes/resources.htm
+++ b/arches_her/templates/views/components/reports/scenes/resources.htm
@@ -5,8 +5,13 @@
 {% block body %}
 <!-- Associated Activities section -->
 <div class="aher-report-section" data-bind="visible: !!dataConfig.activities">
-    <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.activities)}, css: {'fa-angle-double-right': visible.activities(), 'fa-angle-double-up': !visible.activities()}" class="fa toggle"></i> {% trans "Associated Activities" %}</h2>
-    <a data-bind="{if: cards.activities, click: function(){addNewTile(cards.activities)}}"  class="aher-report-a"><i class="fa fa-mail-reply"></i> {% trans "Add Activity" %}</a>
+    <h2 class="aher-report-section-title">
+        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.activities)}, css: {'fa-angle-double-right': visible.activities(), 'fa-angle-double-up': !visible.activities()}, attr: {'aria-expanded': visible.activities() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Associated Activities section"></i>
+        {% trans "Associated Activities" %}
+    </h2>
+    <!-- ko if: cards.activities -->
+    <a href="#" data-bind="click: function(){addNewTile(cards.activities)}"  class="aher-report-a"><i class="fa fa-mail-reply"></i> {% trans "Add Activity" %}</a>
+    <!-- /ko -->
 
     <!-- Collapsible content -->
     <div data-bind="visible: visible.activities" class="aher-report-collapsible-container pad-lft">
@@ -19,11 +24,12 @@
         <div class="aher-report-subsection">
             <div class="firstchild-container">
                 <div class="aher-table" data-bind="">
-                    <table class="table table-striped" cellspacing="0" width="100%">
+                    <p class="aher-table-aria-describedby" id="associated-activity-table_info">Associated activity table.</p>
+                    <table id="associated-activity-table" class="table table-striped" cellspacing="0" width="100%">
                         <thead>
                             <tr class="aher-table-header">
                                 <th>{% trans "Activity" %}</th>
-                                <th class="aher-table-control all"></th>
+                                <th class="aher-table-control all">{% trans "Actions" %}</th>
                             </tr>
                         </thead>
                         <tbody data-bind="dataTablesForEach: { data: activities, dataTableOptions: relatedResourceTwoColumnTableConfig}">
@@ -59,8 +65,13 @@
 
 <!-- Associated Archive section -->
 <div class="aher-report-section" data-bind="visible: !!dataConfig.archive">
-    <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.archive)}, css: {'fa-angle-double-right': visible.archive(), 'fa-angle-double-up': !visible.archive()}" class="fa toggle"></i> {% trans "Associated Archive Objects" %}</h2>
-    <a data-bind="{if: cards.archive, click: function(){addNewTile(cards.archive)}}"  class="aher-report-a"><i class="fa fa-mail-reply"></i> {% trans "Add Archive Object" %}</a>
+    <h2 class="aher-report-section-title">
+        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.archive)}, css: {'fa-angle-double-right': visible.archive(), 'fa-angle-double-up': !visible.archive()}, attr: {'aria-expanded': visible.archive() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Associated Archive Objects section"></i>
+        {% trans "Associated Archive Objects" %}
+    </h2>
+    <!-- ko if: cards.archive -->
+    <a href="#" data-bind="click: function(){addNewTile(cards.archive)}" class="aher-report-a"><i class="fa fa-mail-reply"></i> {% trans "Add Archive Object" %}</a>
+    <!-- /ko -->
 
     <!-- Collapsible content -->
     <div data-bind="visible: visible.archive" class="aher-report-collapsible-container pad-lft">
@@ -73,13 +84,14 @@
         <div class="aher-report-subsection">
             <div class="firstchild-container">
                 <div class="aher-table" data-bind="">
-                    <table class="table table-striped" cellspacing="0" width="100%">
+                    <p class="aher-table-aria-describedby" id="associated-archive-table_info">Associated archive table.</p>
+                    <table id="associated-archive-table" class="table table-striped" cellspacing="0" width="100%">
                         <thead>
                             <tr class="aher-table-header">
                                 <th>{% trans "Archive Holder" %}</th>
                                 <th>{% trans "Title" %}</th>
                                 <th>{% trans "References" %}</th>
-                                <th class="aher-table-control all"></th>
+                                <th class="aher-table-control all">{% trans "Actions" %}</th>
                             </tr>
                         </thead>
                         <tbody data-bind="dataTablesForEach: { data: archive, dataTableOptions: archiveHolderTableConfig}">
@@ -117,25 +129,33 @@
 
 <!-- Associated Consultations section -->
 <div class="aher-report-section" data-bind="visible: !!dataConfig.consultations">
-    <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.consultations)}, css: {'fa-angle-double-right': visible.consultations(), 'fa-angle-double-up': !visible.consultations()}" class="fa toggle"></i> {% trans "Associated Consultations" %}</h2>
-    <a data-bind="{if: cards.consultations, click: function(){addNewTile(cards.consultations)}}" class="aher-report-a"><i class="fa fa-mail-reply"></i> {% trans "Add Consultation" %}</a>
+    <h2 class="aher-report-section-title">
+        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.consultations)}, css: {'fa-angle-double-right': visible.consultations(), 'fa-angle-double-up': !visible.consultations()}, attr: {'aria-expanded': visible.consultations() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Associated Consultations section"></i>
+        {% trans "Associated Consultations" %}
+    </h2>
+    <!-- ko if: cards.consultations -->
+    <a href="#" data-bind="click: function(){addNewTile(cards.consultations)}" class="aher-report-a"><i class="fa fa-mail-reply"></i> {% trans "Add Consultation" %}</a>
+    <!-- /ko -->
 
     <!-- Collapsible content -->
     <div data-bind="visible: visible.consultations" class="aher-report-collapsible-container pad-lft">
 
         <!-- ko ifnot: consultations().length -->
-        <div class="aher-nodata-note">No consultations for this resource</div>
+        <div class="aher-nodata-note">
+            <p data-bind="text:consultations_message"></p>
+        </div>
         <!-- /ko -->
 
         <!-- ko if: consultations().length -->
         <div class="aher-report-subsection">
             <div class="firstchild-container">
                 <div class="aher-table" data-bind="">
-                    <table class="table table-striped" cellspacing="0" width="100%">
+                    <p class="aher-table-aria-describedby" id="associated-consultation-table_info">Associated consultation table.</p>
+                    <table id="associated-consultation-table" class="table table-striped" cellspacing="0" width="100%">
                         <thead>
                             <tr class="aher-table-header">
                                 <th>{% trans "Consultation" %}</th>
-                                <th class="aher-table-control all"></th>
+                                <th class="aher-table-control all">{% trans "Actions" %}</th>
                             </tr>
                         </thead>
                         <tbody data-bind="dataTablesForEach: { data: consultations, dataTableOptions: relatedResourceTwoColumnTableConfig}">
@@ -170,8 +190,13 @@
 
 <!-- Associated Digital Files section -->
 <div class="aher-report-section" data-bind="visible: !!dataConfig.files">
-    <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.files)}, css: {'fa-angle-double-right': visible.files(), 'fa-angle-double-up': !visible.files()}" class="fa toggle"></i> {% trans "Associated Files" %}</h2>
-    <a data-bind="{if: cards.files, click: function(){addNewTile(cards.files)}}"  class="aher-report-a"><i class="fa fa-mail-reply"></i> {% trans "Add File" %}</a>
+    <h2 class="aher-report-section-title">
+        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.files)}, css: {'fa-angle-double-right': visible.files(), 'fa-angle-double-up': !visible.files()}, attr: {'aria-expanded': visible.files() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Associated Files section"></i>
+        {% trans "Associated Files" %}
+    </h2>
+    <!-- ko if: cards.files -->
+    <a href="#" data-bind="click: function(){addNewTile(cards.files)}" class="aher-report-a"><i class="fa fa-mail-reply"></i> {% trans "Add File" %}</a>
+    <!-- /ko -->
 
     <!-- Collapsible content -->
     <div data-bind="visible: visible.files" class="aher-report-collapsible-container pad-lft">
@@ -184,11 +209,12 @@
         <div class="aher-report-subsection">
             <div class="firstchild-container">
                 <div class="aher-table" data-bind="">
-                    <table class="table table-striped" cellspacing="0" width="100%">
+                    <p class="aher-table-aria-describedby" id="associated-digital-file-table_info">Associated digital file table.</p>
+                    <table id="associated-digital-file-table" class="table table-striped" cellspacing="0" width="100%">
                         <thead>
                             <tr class="aher-table-header">
                                 <th>{% trans "File Name" %}</th>
-                                <th class="aher-table-control all"></th>
+                                <th class="aher-table-control all">{% trans "Actions" %}</th>
                             </tr>
                         </thead>
                         <tbody data-bind="dataTablesForEach: { data: files, dataTableOptions: relatedResourceTwoColumnTableConfig}">
@@ -223,8 +249,13 @@
 
 <!-- Associated Monuments section -->
 <div class="aher-report-section" data-bind="visible: !!dataConfig.assets">
-    <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.assets)}, css: {'fa-angle-double-right': visible.assets(), 'fa-angle-double-up': !visible.assets()}" class="fa toggle"></i> {% trans "Associated Monuments/Areas/Artefacts" %}</h2>
-    <a data-bind="{if: cards.assets, click: function(){addNewTile(cards.assets)}}"  class="aher-report-a"><i class="fa fa-mail-reply"></i> {% trans "Add Resource" %}</a>
+    <h2 class="aher-report-section-title">
+        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.assets)}, css: {'fa-angle-double-right': visible.assets(), 'fa-angle-double-up': !visible.assets()}, attr: {'aria-expanded': visible.assets() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Associated Monuments/Areas/Artefacts section"></i>
+        {% trans "Associated Monuments/Areas/Artefacts" %}
+    </h2>
+    <!-- ko if: cards.assets -->
+    <a href="#" data-bind="click: function(){addNewTile(cards.assets)}" class="aher-report-a"><i class="fa fa-mail-reply"></i> {% trans "Add Resource" %}</a>
+    <!-- /ko -->
 
     <!-- Collapsible content -->
     <div data-bind="visible: visible.assets" class="aher-report-collapsible-container pad-lft">
@@ -237,12 +268,13 @@
         <div class="aher-report-subsection">
             <div class="firstchild-container">
                 <div class="aher-table" data-bind="">
-                    <table class="table table-striped" cellspacing="0" width="100%">
+                    <p class="aher-table-aria-describedby" id="associated-monument-table_info">Associated monument/area/artefact table.</p>
+                    <table id="associated-monument-table" class="table table-striped" cellspacing="0" width="100%">
                         <thead>
                             <tr class="aher-table-header">
                                 <th>{% trans "Resource Name" %}</th>
                                 <th>{% trans "Association" %}</th>
-                                <th class="aher-table-control all"></th>
+                                <th class="aher-table-control all">{% trans "Actions" %}</th>
                             </tr>
                         </thead>
                         <tbody data-bind="dataTablesForEach: { data: assets, dataTableOptions: relatedResourceThreeColumnTableConfig}">
@@ -280,8 +312,14 @@
 
 <!-- Associated People and Organisations section -->
 <div class="aher-report-section" data-bind="visible: !!dataConfig.actors">
-    <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.actors)}, css: {'fa-angle-double-right': visible.actors(), 'fa-angle-double-up': !visible.actors()}" class="fa toggle"></i> {% trans "Associated People and Organisations" %}</h2>
-    <a data-bind="{if: cards.actors, click: function(){addNewTile(cards.actors)}}" class="aher-report-a"><i class="fa fa-mail-reply"></i> {% trans "Add Person or Organisation" %}</a>
+    <h2 class="aher-report-section-title">
+        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.actors)}, css: {'fa-angle-double-right': visible.actors(), 'fa-angle-double-up': !visible.actors()}, attr: {'aria-expanded': visible.actors() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Associated People and Organisations section"></i>
+        {% trans "Associated People and Organisations" %}
+    </h2>
+    <!-- ko if: cards.actors -->
+    <a href="#" data-bind="click: function(){addNewTile(cards.actors)}" class="aher-report-a"><i class="fa fa-mail-reply"></i> {% trans "Add Person or Organisation" %}</a>
+    <!-- /ko -->
+
     <!-- Collapsible content -->
     <div data-bind="visible: visible.actors" class="aher-report-collapsible-container pad-lft">
 
@@ -293,11 +331,12 @@
         <div class="aher-report-subsection">
             <div class="firstchild-container">
                 <div class="aher-table" data-bind="">
-                    <table class="table table-striped" cellspacing="0" width="100%">
+                    <p class="aher-table-aria-describedby" id="associated-people-and-organisation-table_info">Associated people and organisation table.</p>
+                    <table id="associated-people-and-organisation-table" class="table table-striped" cellspacing="0" width="100%">
                         <thead>
                             <tr class="aher-table-header">
                                 <th>{% trans "Associated Person or Organisation" %}</th>
-                                <th class="aher-table-control all"></th>
+                                <th class="aher-table-control all">{% trans "Actions" %}</th>
                             </tr>
                         </thead>
                         <tbody data-bind="dataTablesForEach: { data: actors, dataTableOptions: relatedResourceTwoColumnTableConfig}">
@@ -333,7 +372,10 @@
 
 <!-- Related Application Area section -->
 <div class="aher-report-section" data-bind="visible: !!dataConfig.relatedApplicationArea">
-    <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.applicationArea)}, css: {'fa-angle-double-right': visible.applicationArea(), 'fa-angle-double-up': !visible.applicationArea()}" class="fa toggle"></i> {% trans "Related Application Areas" %}</h2>
+    <h2 class="aher-report-section-title">
+        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.applicationArea)}, css: {'fa-angle-double-right': visible.applicationArea(), 'fa-angle-double-up': !visible.applicationArea()}, attr: {'aria-expanded': visible.applicationArea() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Related Application Areas section"></i>
+        {% trans "Related Application Areas" %}
+    </h2>
     <!-- Collapsible content -->
     <div data-bind="visible: visible.applicationArea" class="aher-report-collapsible-container pad-lft">
         <!-- ko ifnot: applicationArea().length -->
@@ -343,11 +385,12 @@
         <div class="aher-report-subsection">
             <div class="firstchild-container">
                 <div class="aher-table" data-bind="">
-                    <table class="table table-striped" cellspacing="0" width="100%">
+                    <p class="aher-table-aria-describedby" id="related-application-area-table_info">Related application area table.</p>
+                    <table id="related-application-area-table" class="table table-striped" cellspacing="0" width="100%">
                         <thead>
                             <tr class="aher-table-header">
                                 <th>{% trans "Application Area" %}</th>
-                                <th class="aher-table-control all"></th>
+                                <th class="aher-table-control all">{% trans "Actions" %}</th>
                             </tr>
                         </thead>
                         <tbody data-bind="dataTablesForEach: { data: applicationArea, dataTableOptions: applicationAreaTableConfig}">
@@ -380,8 +423,13 @@
 
 <!-- Translation section -->
 <div class="aher-report-section" data-bind="visible: !!dataConfig.translation">
-    <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.translation)}, css: {'fa-angle-double-right': visible.translation(), 'fa-angle-double-up': !visible.translation()}" class="fa toggle"></i> {% trans "Translations" %}</h2>
-    <a data-bind="{if: cards.translation, click: function(){addNewTile(cards.translation)}}"  class="aher-report-a"><i class="fa fa-mail-reply"></i> {% trans "Add Translation" %}</a>
+    <h2 class="aher-report-section-title">
+        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.translation)}, css: {'fa-angle-double-right': visible.translation(), 'fa-angle-double-up': !visible.translation()}, attr: {'aria-expanded': visible.translation() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Translations section"></i>
+        {% trans "Translations" %}
+    </h2>
+    <!-- ko if: cards.translation -->
+    <a href="#" data-bind="click: function(){addNewTile(cards.translation)}" class="aher-report-a"><i class="fa fa-mail-reply"></i> {% trans "Add Translation" %}</a>
+    <!-- /ko -->
 
     <!-- Collapsible content -->
     <div data-bind="visible: visible.translation" class="aher-report-collapsible-container pad-lft">
@@ -394,11 +442,12 @@
         <div class="aher-report-subsection">
             <div class="firstchild-container">
                 <div class="aher-table" data-bind="">
-                    <table class="table table-striped" cellspacing="0" width="100%">
+                    <p class="aher-table-aria-describedby" id="translation-table_info">Translation table.</p>
+                    <table id="translation-table" class="table table-striped" cellspacing="0" width="100%">
                         <thead>
                             <tr class="aher-table-header">
                                 <th>{% trans "Translation" %}</th>
-                                <th class="aher-table-control all"></th>
+                                <th class="aher-table-control all">{% trans "Actions" %}</th>
                             </tr>
                         </thead>
                         <tbody data-bind="dataTablesForEach: { data: translation, dataTableOptions: relatedResourceTwoColumnTableConfig}">
@@ -426,8 +475,13 @@
 
 <!-- Period section -->
 <div class="aher-report-section" data-bind="visible: !!dataConfig.period">
-    <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.period)}, css: {'fa-angle-double-right': visible.period(), 'fa-angle-double-up': !visible.period()}" class="fa toggle"></i> {% trans "Periods" %}</h2>
-    <a data-bind="{if: cards.period, click: function(){addNewTile(cards.period)}}"  class="aher-report-a"><i class="fa fa-mail-reply"></i> {% trans "Period" %}</a>
+    <h2 class="aher-report-section-title">
+        <i tabindex="0" data-bind="click: function() {toggleVisibility(visible.period)}, css: {'fa-angle-double-right': visible.period(), 'fa-angle-double-up': !visible.period()}, attr: {'aria-expanded': visible.period() ? 'false' : 'true' }" class="fa toggle" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }" aria-label="Expand/collapse Periods section"></i>
+        {% trans "Periods" %}
+    </h2>
+    <!-- ko if: cards.period -->
+    <a href="#" data-bind="click: function(){addNewTile(cards.period)}" class="aher-report-a"><i class="fa fa-mail-reply"></i> {% trans "Period" %}</a>
+    <!-- /ko -->
 
     <!-- Collapsible content -->
     <div data-bind="visible: visible.period" class="aher-report-collapsible-container pad-lft">
@@ -440,11 +494,12 @@
         <div class="aher-report-subsection">
             <div class="firstchild-container">
                 <div class="aher-table" data-bind="">
-                    <table class="table table-striped" cellspacing="0" width="100%">
+                    <p class="aher-table-aria-describedby" id="period-table_info">Period table.</p>
+                    <table id="period-table" class="table table-striped" cellspacing="0" width="100%">
                         <thead>
                             <tr class="aher-table-header">
                                 <th>{% trans "Period" %}</th>
-                                <th class="aher-table-control all"></th>
+                                <th class="aher-table-control all">{% trans "Actions" %}</th>
                             </tr>
                         </thead>
                         <tbody data-bind="dataTablesForEach: { data: period, dataTableOptions: relatedResourceTwoColumnTableConfig}">


### PR DESCRIPTION
Remedies issue #1044

- resourceinstanceid object added to the resourceDataConfig for Activity, Area, Aircraft, Maritime, Monument and Person
- code added to provide a message to the user when they either do not have permissions to access associated consultation data or when there are no associated consultation records