### PR TITLE
1052 Build report or resource link based on originator URL

### DIFF
--- a/arches_her/media/js/utils/report.js
+++ b/arches_her/media/js/utils/report.js
@@ -190,7 +190,13 @@ define([
             if(node) {
                 const resourceId = node?.resourceId || node?.instance_details?.[0]?.resourceId;
                 if(resourceId){
-                    return `${arches.urls.resource}/${resourceId}`;
+                    urlPathname = window.location.pathname
+                    if(urlPathname.includes("resource")){
+                        return `${arches.urls.resource}/${resourceId}`;
+                    }
+                    else{
+                        return `${arches.urls.resource_report}${resourceId}`;
+                    }
                 }
             }
         },        


### PR DESCRIPTION
Fulfils the requirements of #1052 

Modifies the getResourceLink function to check the urlPathname and use that to generate the resulting link with either report or resource in it.

This removes the issue of users being sent to the /resource/ URL even when they don't have edit access on the resource (which then results in an error).