### PR TITLE
#1054 - Update resourceDataConfig in report JS files

### DIFF
--- a/arches_her/media/js/views/components/reports/activity.js
+++ b/arches_her/media/js/views/components/reports/activity.js
@@ -66,7 +66,10 @@ define([
                 archive: 'associated archive objects',
                 files: 'digital files',
                 assets: 'associated monuments and areas',
+                period: undefined,
                 actors: undefined,
+                consultations: 'associated consultations',
+                activities: 'associated activities',
                 resourceinstanceid: ko.unwrap(self.reportMetadata)?.resourceinstanceid
             }
 

--- a/arches_her/media/js/views/components/reports/application-area.js
+++ b/arches_her/media/js/views/components/reports/application-area.js
@@ -51,7 +51,12 @@ define([
 
             self.resourceDataConfig = {
                 files: 'digital file(s)',
-                actors: undefined
+                assets: 'associated monuments, areas and artefacts',
+                activities: 'associated activities',
+                actors: undefined,
+                consultations: 'associated consultations',
+                archive: undefined,
+                resourceinstanceid: ko.unwrap(self.reportMetadata)?.resourceinstanceid,
             };
 
             self.locationDataConfig = {
@@ -93,10 +98,10 @@ define([
                 })
 
                 self.resourcesCards = {
-                    activities: self.cards?.['associated activities'],
                     consultations: self.cards?.['associated consultations'],
+                    activities: self.cards?.['associated activities'],
+                    assets: self.cards?.['associated monuments, areas and artefacts'],
                     files: self.cards?.['associated digital files'],
-                    assets: self.cards?.['associated heritage assets'],
                 };
 
                 self.nameCards = {

--- a/arches_her/media/js/views/components/reports/archive-source.js
+++ b/arches_her/media/js/views/components/reports/archive-source.js
@@ -47,7 +47,9 @@ define([
                 consultations: undefined,
                 assets: undefined,
                 period: 'periods',
-                actors: undefined
+                actors: undefined,
+                archive: undefined,
+                resourceinstanceid: ko.unwrap(self.reportMetadata)?.resourceinstanceid
             };
 
             self.visible = {

--- a/arches_her/media/js/views/components/reports/area.js
+++ b/arches_her/media/js/views/components/reports/area.js
@@ -55,7 +55,12 @@ define([
 
             self.resourceDataConfig = {
                 files: 'digital file(s)',
+                activities: 'associated activities',
+                consultations: 'associated consultations',
+                assets: 'associated monuments, areas and artefacts',
+                period: undefined,
                 actors: undefined,
+                archive: 'associated archives',
                 resourceinstanceid: ko.unwrap(self.reportMetadata)?.resourceinstanceid
             };
 

--- a/arches_her/media/js/views/components/reports/artefact.js
+++ b/arches_her/media/js/views/components/reports/artefact.js
@@ -79,9 +79,13 @@ define([
 
             self.resourceDataConfig = {
                 files: 'digital file(s)',
+                activities: 'associated activities',
                 consultations: undefined,
+                assets: 'associated monuments, areas and artefacts',
+                period: undefined,
+                actors: undefined,
                 archive: undefined,
-                actors: undefined
+                resourceinstanceid: ko.unwrap(self.reportMetadata)?.resourceinstanceid
             };
 
             self.nameCards = {};

--- a/arches_her/media/js/views/components/reports/bibliographic-source.js
+++ b/arches_her/media/js/views/components/reports/bibliographic-source.js
@@ -55,12 +55,15 @@ define([
             };
 
             self.resourceDataConfig = {
+                files: 'digital file(s)',
                 activities: undefined,
                 archive: undefined,
                 consultations: undefined,
                 assets: undefined,
-                files: 'digital file(s)',
-                actors: undefined
+                period: undefined,
+                actors: undefined,
+                archive: undefined,
+                resourceinstanceid: ko.unwrap(self.reportMetadata)?.resourceinstanceid
             };
 
             self.publication = ko.observableArray();

--- a/arches_her/media/js/views/components/reports/consultation.js
+++ b/arches_her/media/js/views/components/reports/consultation.js
@@ -58,8 +58,10 @@ define([
             self.resourcesDataConfig = {
                 assets: 'related monuments and areas',
                 files: 'file(s)',
-                relatedApplicationArea: 'consultation area',
+                relatedApplicationArea: undefined,
+                consultation: 'associated consultations',
                 actors: undefined,
+                archive: undefined,
                 resourceinstanceid: ko.unwrap(self.reportMetadata)?.resourceinstanceid
             };
 

--- a/arches_her/media/js/views/components/reports/heritage-story.js
+++ b/arches_her/media/js/views/components/reports/heritage-story.js
@@ -38,14 +38,15 @@ define([
             };
 
             self.resourceDataConfig = {
-                activities: undefined,
+                activities: 'associated activities',
                 consultations: undefined,
-                files: undefined,
-                assets: 'associated heritage assets, areas and artefacts',
+                files: 'digital file(s)',
+                assets: 'associated monuments, areas and artefacts',
                 translation: 'translation',
                 period: 'temporal coverage',
                 archive: undefined,
-                actors: 'associated actors'
+                actors: 'associated actors',
+                resourceinstanceid: ko.unwrap(self.reportMetadata)?.resourceinstanceid
             };
 
             self.locationDataConfig = {

--- a/arches_her/media/js/views/components/reports/historic-aircraft.js
+++ b/arches_her/media/js/views/components/reports/historic-aircraft.js
@@ -57,7 +57,12 @@ define([
 
             self.resourceDataConfig = {
                 files: 'digital file(s)',
+                activities: 'associated activities',
+                consultations: 'associated consultations',
+                assets: 'associated monuments, areas and artefacts',
+                period: undefined,
                 actors: undefined,
+                archive: 'associated archives',
                 resourceinstanceid: ko.unwrap(self.reportMetadata)?.resourceinstanceid
             }
 

--- a/arches_her/media/js/views/components/reports/historic-landscape-characterization.js
+++ b/arches_her/media/js/views/components/reports/historic-landscape-characterization.js
@@ -56,11 +56,14 @@ define([
                 citation: 'bibliographic source citation'
             };
             self.resourceDataConfig = {
-                activities: undefined,
                 files: undefined,
+                activities: undefined,
                 consultations: undefined,
+                assets: 'associated monuments, areas and artefacts',
+                period: undefined,
+                actors: undefined,
                 archive: undefined,
-                actors: undefined
+                resourceinstanceid: ko.unwrap(self.reportMetadata)?.resourceinstanceid
             }
 
             self.nameCards = {};

--- a/arches_her/media/js/views/components/reports/maritime-vessel.js
+++ b/arches_her/media/js/views/components/reports/maritime-vessel.js
@@ -67,7 +67,12 @@ define([
 
             self.resourceDataConfig = {
                 files: 'digital file(s)',
+                activities: 'associated activities',
+                consultations: 'associated consultations',
+                assets: 'associated monuments, areas and artefacts',
+                period: undefined,
                 actors: undefined,
+                archive: 'associated archives',
                 resourceinstanceid: ko.unwrap(self.reportMetadata)?.resourceinstanceid
             }
 

--- a/arches_her/media/js/views/components/reports/monument.js
+++ b/arches_her/media/js/views/components/reports/monument.js
@@ -51,9 +51,13 @@ define([
             };
 
             self.resourceDataConfig = {
-                activities: 'associated activities',
                 files: 'digital file(s)',
+                activities: 'associated activities',
+                consultations: 'associated consultations',
+                assets: 'associated monuments, areas and artefacts',
+                period: undefined,
                 actors: undefined,
+                archive: 'associated archives',
                 resourceinstanceid: ko.unwrap(self.reportMetadata)?.resourceinstanceid
             }
 

--- a/arches_her/media/js/views/components/reports/organization.js
+++ b/arches_her/media/js/views/components/reports/organization.js
@@ -55,10 +55,14 @@ define([
             };
 
             self.resourceDataConfig = {
-                consultations: undefined,
                 files: undefined,
+                activities: 'associated activities',
+                consultations: undefined,
+                assets: 'associated monuments, areas and artefacts',
+                period: undefined,
+                actors: undefined,
                 archive: undefined,
-                actors: undefined
+                resourceinstanceid: ko.unwrap(self.reportMetadata)?.resourceinstanceid
             };
 
             self.nameCards = {};

--- a/arches_her/media/js/views/components/reports/person.js
+++ b/arches_her/media/js/views/components/reports/person.js
@@ -80,8 +80,12 @@ define([
 
             self.resourceDataConfig = {
                 files: 'digital file(s)',
-                archive: undefined,
+                activities: 'associated activities',
+                consultations: 'associated consultations',
+                assets: 'associated monuments, areas and artefacts',
+                period: undefined,
                 actors: undefined,
+                archive: undefined,
                 resourceinstanceid: ko.unwrap(self.reportMetadata)?.resourceinstanceid
             };
             self.nameCards = {};


### PR DESCRIPTION
Fixes issue raised in #1054 

resourceDataConfig is now updated for the following JS files to reflect the information that might be stored in each resource model:

- Activity
- Application Area
- Archive Source
- Area
- Artefact
- Bibliographic Source
- Consultation
- Heritage Story
- Historic Aircraft
- Historic Landscape Characterization
- Maritime Vessel
- Monument
- Organization
- Person