### PR TITLE
Give three administrative area nodes unique aliases

### DIFF
--- a/arches_her/pkg/graphs/resource_models/Area.json
+++ b/arches_her/pkg/graphs/resource_models/Area.json
@@ -16930,7 +16930,7 @@
                     "sortorder": 0
                 },
                 {
-                    "alias": "area_metatype",
+                    "alias": "admin_area_metatype",
                     "config": {
                         "rdmCollection": "1e63c514-eb9d-48d3-94b5-35e060e5f368"
                     },
@@ -17260,7 +17260,7 @@
                     "sortorder": 0
                 },
                 {
-                    "alias": "area_name_metatype",
+                    "alias": "admin_area_name_metatype",
                     "config": {
                         "rdmCollection": "1e63c514-eb9d-48d3-94b5-35e060e5f368"
                     },
@@ -17302,14 +17302,14 @@
                     "sortorder": 0
                 },
                 {
-                    "alias": "area_type",
+                    "alias": "admin_area_type",
                     "config": {
                         "rdmCollection": "59a0a035-bbd0-4e5e-9528-862790edc610"
                     },
                     "datatype": "concept",
                     "description": null,
                     "exportable": true,
-                    "fieldname": "Area__Type",
+                    "fieldname": "Admin_Area_Type",
                     "graph_id": "979aaf0b-7042-11ea-9674-287fcf6a5e72",
                     "is_collector": false,
                     "isrequired": false,

--- a/arches_her/pkg/graphs/resource_models/Area.json
+++ b/arches_her/pkg/graphs/resource_models/Area.json
@@ -17309,7 +17309,7 @@
                     "datatype": "concept",
                     "description": null,
                     "exportable": true,
-                    "fieldname": "Admin_Area_Type",
+                    "fieldname": "AArea_Type",
                     "graph_id": "979aaf0b-7042-11ea-9674-287fcf6a5e72",
                     "is_collector": false,
                     "isrequired": false,


### PR DESCRIPTION
Resolves issue #1059

Gives the following Area nodes unique aliases so they don't cause the above error when importing the package.
- area_metatype -> admin_area_metatype
- area_name_metatype -> admin_area_name_metatype
- area_type -> admin_area_type  - also changes the shapefile export fieldname from Area__Type to AArea_Type to try to be more specific to the administrative area nodegroup.