### PR TITLE
Correcting two Role Type concepts spelling/formatting

### DIFF
--- a/arches_her/pkg/reference_data/concepts/FISH_Archaeological_Sciences_Thesaurus_20200127.xml
+++ b/arches_her/pkg/reference_data/concepts/FISH_Archaeological_Sciences_Thesaurus_20200127.xml
@@ -397,7 +397,7 @@
     </skos:narrower>
     <skos:narrower>
       <skos:Concept rdf:about="http://localhost:8000/2c167ba9-b28b-3f1b-bdd4-a2d21c4af186">
-        <skos:prefLabel xml:lang="en">{"id": "8bb95ab7-851a-44f8-b39b-2e61a32ab556", "value": "Mitochondrial Dna"}</skos:prefLabel>
+        <skos:prefLabel xml:lang="en">{"id": "8bb95ab7-851a-44f8-b39b-2e61a32ab556", "value": "Mitochondrial DNA"}</skos:prefLabel>
         <skos:scopeNote xml:lang="en">{"id": "2426aaa9-0d84-442a-a440-f310378141ff", "value": "A dating technique for the founding of individual populations based on the assumption of steady rates of mutation in mitochondrial DNA. Sometimes used to produce dates for stratigraphic layers containing fossil specimens of populations."}</skos:scopeNote>
         <dcterms:identifier xml:lang="en">{"id": "4760da02-2666-4a19-adbe-848ab19b5427", "value": "http://purl.org/heritagedata/schemes/560/concepts/142170"}</dcterms:identifier>
         <skos:inScheme rdf:resource="http://localhost:8000/6fed8739-bdef-3186-b645-775efcfaefaa"/>

--- a/arches_her/pkg/reference_data/concepts/Geology_20200108.xml
+++ b/arches_her/pkg/reference_data/concepts/Geology_20200108.xml
@@ -448,7 +448,7 @@
   <skos:Concept rdf:about="http://localhost:8000/8dffc9df-5f44-4430-87d7-9af3c04b92b4">
     <skos:inScheme rdf:resource="http://localhost:8000/e83b293e-2e6c-48a1-ab09-28311296daea"/>
     <dcterms:identifier xml:lang="en">{"id": "e9d6f884-c64d-44bb-ac5c-5cd917148cd3", "value": "http://localhost:8000/8dffc9df-5f44-4430-87d7-9af3c04b92b4"}</dcterms:identifier>
-    <skos:prefLabel xml:lang="en">{"id": "6fd7d774-55ca-4731-8c9c-796a38cf4ed3", "value": "Collovium"}</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">{"id": "6fd7d774-55ca-4731-8c9c-796a38cf4ed3", "value": "Colluvium"}</skos:prefLabel>
     <skos:altLabel xml:lang="en">{"id": "3392517c-c385-4495-9afb-762db7fd6f2d", "value": "ALL4"}</skos:altLabel>
   </skos:Concept>
   <skos:Concept rdf:about="http://localhost:8000/e2690c5f-baf4-405a-8b89-26a9e2223dd9">

--- a/arches_her/pkg/reference_data/concepts/Land_Use_Classification_20200127.xml
+++ b/arches_her/pkg/reference_data/concepts/Land_Use_Classification_20200127.xml
@@ -169,7 +169,7 @@
         <dcterms:identifier xml:lang="en">{"id": "73e35488-7bc7-4bc3-9c44-fbda81702f36", "value": "http://localhost:8000/b15c8f53-19f5-49ef-929e-d75578aedf61"}</dcterms:identifier>
         <skos:inScheme rdf:resource="http://localhost:8000/35bf7f21-1d0d-43d2-83d3-363075c1ddd0"/>
         <skos:scopeNote xml:lang="en">{"id": "bcbc6d57-792f-4db1-b787-9576ec5f962f", "value": "Specify in Description using: golf course, playing fields etc."}</skos:scopeNote>
-        <skos:prefLabel xml:lang="en">{"id": "d21f9bd2-ea29-4755-bf8f-1f6e1bb7ffff", "value": "Other 14  (Recreational usage)"}</skos:prefLabel>
+        <skos:prefLabel xml:lang="en">{"id": "d21f9bd2-ea29-4755-bf8f-1f6e1bb7ffff", "value": "Other 14 (Recreational usage)"}</skos:prefLabel>
       </skos:Concept>
     </skos:narrower>
     <skos:narrower>

--- a/arches_her/pkg/reference_data/concepts/Role_Type_20200127.xml
+++ b/arches_her/pkg/reference_data/concepts/Role_Type_20200127.xml
@@ -5,7 +5,7 @@
   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 >
   <skos:Concept rdf:about="http://localhost:8000/496206ca-001d-4beb-bb07-6519ee0c037f">
-    <skos:prefLabel xml:lang="en">{"id": "58efc6e4-840b-43e5-b91f-0cf087833e75", "value": "Archaeological FIeld Investigator"}</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">{"id": "58efc6e4-840b-43e5-b91f-0cf087833e75", "value": "Archaeological Field Investigator"}</skos:prefLabel>
     <skos:altLabel xml:lang="en">{"id": "ca09aa2f-c9c2-4a70-a657-57a88e56ee63", "value": "AFI"}</skos:altLabel>
     <skos:inScheme>
       <skos:ConceptScheme rdf:about="http://localhost:8000/a6bb9d1a-a318-4b6b-bc2d-20450996f96a">
@@ -193,7 +193,7 @@
   </skos:Concept>
   <skos:Concept rdf:about="http://localhost:8000/11f88573-1758-4d0f-98f4-6b5081a0ee3b">
     <skos:inScheme rdf:resource="http://localhost:8000/a6bb9d1a-a318-4b6b-bc2d-20450996f96a"/>
-    <skos:prefLabel xml:lang="en">{"id": "143d7eb8-d353-4d75-83ad-c39431fd8f6e", "value": "Funding Body/FInancier"}</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">{"id": "143d7eb8-d353-4d75-83ad-c39431fd8f6e", "value": "Funding Body/Financier"}</skos:prefLabel>
     <dcterms:identifier xml:lang="en">{"id": "4ba40908-a886-4a5e-8dfb-dc2b258da6a6", "value": "http://www.archesproject.org/11f88573-1758-4d0f-98f4-6b5081a0ee3b"}</dcterms:identifier>
   </skos:Concept>
   <skos:Concept rdf:about="http://localhost:8000/fc317036-4ec2-4106-a7c6-3dc06f9c7851">


### PR DESCRIPTION
Resolves issue #1062 

Correcting the two following concept's formatting:
- `"143d7eb8-d353-4d75-83ad-c39431fd8f6e": "Funding Body/FInancier"`
- `"58efc6e4-840b-43e5-b91f-0cf087833e75": "Archaeological FIeld Investigator"`

Initial commit only changes the RoleType xml file, but the Role Type ConceptScheme is used in 10 resource models and thus exists in each MODEL_concepts.json within the package.  Should these be changed also?