### PR TITLE
#1149 Consultation Workflow Error messages

### DIFF
--- a/arches_her/functions/consultation_status_function.py
+++ b/arches_her/functions/consultation_status_function.py
@@ -72,7 +72,7 @@ class ConsultationStatusFunction(BaseFunction):
                     date_comp_tile_filter = Tile.objects.filter(resourceinstance_id=tile.resourceinstance_id,nodegroup_id=date_comp_node.nodegroup_id)
                     if len(date_comp_tile_filter) > 0:
                         date_comp_tile = date_comp_tile_filter[0]
-                if  date_comp_tile != None:
+                if  (date_comp_tile != None) and (tile.nodegroup_id == str(date_comp_tile.nodegroup_id)):
                     datatype_factory = DataTypeFactory()
                     datatype = datatype_factory.get_instance(date_comp_node.datatype)
                     date_comp_value = datatype.get_display_value(tile,date_comp_node)
@@ -85,11 +85,11 @@ class ConsultationStatusFunction(BaseFunction):
                             return
                     else:
                         return
+
             else:
                 self.handle_boolean_tile(tile,cons_status_bool_nodeid,cons_status_bool_nodeid,True)
                 return
 
-            return
         except Exception as e:
             self.logger.error(e,"Could not check boolean tile")
             return

--- a/arches_her/media/js/views/components/workflows/consultation/consultation-dates-step.js
+++ b/arches_her/media/js/views/components/workflows/consultation/consultation-dates-step.js
@@ -32,11 +32,16 @@ define([
                 $.get(
                     arches.urls.resource_descriptors + id,
                     function(descriptors) {
-                        descriptors.displayname.forEach(function(displayname) {
-                            if (displayname.language === activeLang) {
-                                retStr == '' ? retStr = displayname.value : retStr += (', '+displayname.value);
-                            }
-                        });
+                        if (typeof descriptors.displayname === 'string') {
+                            retStr == '' ? retStr = descriptors.displayname : retStr += (', '+ descriptors.displayname);
+                        }
+                        else {
+                            descriptors.displayname.forEach(function(displayname) {
+                                if (displayname.language === activeLang) {
+                                    retStr == '' ? retStr = displayname.value : retStr += (', '+displayname.value);
+                                }
+                            });
+                        }   
                         self.displayName(retStr);
                     }
                 );
@@ -52,6 +57,10 @@ define([
                 nameCardTile = nameCard.getNewTile();
             } else {
                 nameCardTile = nameCard.tiles()[0];
+            }
+            
+            if (typeof nameCardTile.data[self.consultationNameNodeId] !== 'function'){
+                nameCardTile.data[self.consultationNameNodeId] = ko.observable(nameCardTile.data[self.consultationNameNodeId]);
             }
             nameCardTile.data[self.consultationNameNodeId](self.createI18nString(self.concatName()));
             nameCardTile.transactionId = self.workflowId;

--- a/arches_her/media/js/views/components/workflows/consultation/consultation-map-step.js
+++ b/arches_her/media/js/views/components/workflows/consultation/consultation-map-step.js
@@ -150,25 +150,31 @@ define([
 
         if (tiles.length > 0) {
             var resourceIds = koMapping.toJS(tiles[0].data[RelatedApplicationAreaNode]) || [];
-            $.getJSON({
-                url: arches.urls.geojson,
-                data: {
-                    resourceid:resourceIds.join(',')
-                }
-            }, function(geojson) {
-                if (geojson.features.length > 0) {
-                    if (!geoJSON || geoJSON.features.length === 0) {
-                        self.applicationAreaBounds(geojsonExtent(geojson));
+            if (resourceIds.length > 0){
+                var resourceIdsArray = resourceIds.map(function(resourceIdObject) {
+                    return resourceIdObject.resourceId;
+                });
+                var resourceIdsString = resourceIdsArray.join(',');
+                $.getJSON({
+                    url: arches.urls.geojson,
+                    data: {
+                        resourceid: resourceIdsString
                     }
-                    if (self.map()) {
-                        self.map().getSource('related-application-area').setData(geojson);
-                    } else {
-                        self.map.subscribe(function(map) {
-                            map.getSource('related-application-area').setData(geojson);
-                        });
+                }, function(geojson) {
+                    if (geojson.features.length > 0) {
+                        if (!geoJSON || geoJSON.features.length === 0) {
+                            self.applicationAreaBounds(geojsonExtent(geojson));
+                        }
+                        if (self.map()) {
+                            self.map().getSource('related-application-area').setData(geojson);
+                        } else {
+                            self.map.subscribe(function(map) {
+                                map.getSource('related-application-area').setData(geojson);
+                            });
+                        }
                     }
-                }
-            });
+                });
+            }
         }
 
     }

--- a/arches_her/media/js/views/components/workflows/consultation/consultation-map-step.js
+++ b/arches_her/media/js/views/components/workflows/consultation/consultation-map-step.js
@@ -151,8 +151,8 @@ define([
         if (tiles.length > 0) {
             var resourceObjects = koMapping.toJS(tiles[0].data[RelatedApplicationAreaNode]) || [];
             if (resourceObjects.length > 0){
-                var resourceIdsArray = resourceObjects.map(function(resourceIdObject) {
-                    return resourceIdObject.resourceId;
+                var resourceIdsArray = resourceObjects.map(function(resourceObject) {
+                    return resourceObject.resourceId;
                 });
                 var resourceIds = resourceIdsArray.join(',');
                 $.getJSON({

--- a/arches_her/media/js/views/components/workflows/consultation/consultation-map-step.js
+++ b/arches_her/media/js/views/components/workflows/consultation/consultation-map-step.js
@@ -149,16 +149,16 @@ define([
         var tiles = self.getTiles(ConsultationLocationNodegroup);
 
         if (tiles.length > 0) {
-            var resourceIds = koMapping.toJS(tiles[0].data[RelatedApplicationAreaNode]) || [];
-            if (resourceIds.length > 0){
-                var resourceIdsArray = resourceIds.map(function(resourceIdObject) {
+            var resourceObjects = koMapping.toJS(tiles[0].data[RelatedApplicationAreaNode]) || [];
+            if (resourceObjects.length > 0){
+                var resourceIdsArray = resourceObjects.map(function(resourceIdObject) {
                     return resourceIdObject.resourceId;
                 });
-                var resourceIdsString = resourceIdsArray.join(',');
+                var resourceIds = resourceIdsArray.join(',');
                 $.getJSON({
                     url: arches.urls.geojson,
                     data: {
-                        resourceid: resourceIdsString
+                        resourceid: resourceIds
                     }
                 }, function(geojson) {
                     if (geojson.features.length > 0) {


### PR DESCRIPTION
Error message was returned due to consultation-map-step.js trying to pass a related application area resource object as a resourceid string as the data element of a JSON query.

Code now extracts the resourceid from each related application area resource object and builds a string of resourceids to use in the query.

Fixes #1149 