### PR TITLE
#1167 Associated Construction Phase not visible in reports

### DIFF
--- a/arches_her/media/js/views/components/reports/scenes/classifications.js
+++ b/arches_her/media/js/views/components/reports/scenes/classifications.js
@@ -368,6 +368,7 @@ function(_, ko, arches, reportUtils, ClassificationsTemplate) {
                             testPaths:[
                                 ['associated area phase'],
                                 ['associated asset construction phase'],
+                                ['associated monument construction phase'],
                             ]}
                         );
                         const component = self.getNodeValue(x, 'component', 'component type');


### PR DESCRIPTION
Fixes #1167 

Added associated monument construction phase to the testPaths for constuctonPhase in classifications.js
