### PR TITLE
Accessibility statement plugin - content & styling

### DIFF
--- a/arches_her/media/css/accessibility-plugin.css
+++ b/arches_her/media/css/accessibility-plugin.css
@@ -1,0 +1,8 @@
+.accessibility-statement {
+    font-size: 1.2rem;
+    padding: 1em;
+}
+
+.accessibility-statement h2{
+    font-size: 1.6rem;
+}

--- a/arches_her/media/css/project.css
+++ b/arches_her/media/css/project.css
@@ -1,5 +1,6 @@
 @import url(./report_templates.css);
 @import url(./bng-filter.css);
+@import url(./accessibility-plugin.css);
 
 .workflow-panel.navbarclosed {
     min-width: 50px;

--- a/arches_her/pkg/extensions/css/accessibility-plugin.css
+++ b/arches_her/pkg/extensions/css/accessibility-plugin.css
@@ -1,0 +1,8 @@
+.accessibility-statement {
+    font-size: 1.2rem;
+    padding: 1em;
+}
+
+.accessibility-statement h2{
+    font-size: 1.6rem;
+}

--- a/arches_her/pkg/extensions/plugins/accessibility/accessibility.htm
+++ b/arches_her/pkg/extensions/plugins/accessibility/accessibility.htm
@@ -1,11 +1,14 @@
 {% load i18n %}
-
 <div class="accessibility-statement">
-    <h2>Accessibility statement - IN DEVELOPMENT</h2>
+    <h2>Accessibility statement - Plugin</h2>
     <p>
-        This is the default text for this application's accessibility statement.
+        <strong>[THIS CONTENT IS NOT AN ACCESSIBILITY STATEMENT]</strong>
     </p>
     <p>
-        An official note on the creation of accessibility statement will be added to this plugin.
+        You can use this plugin to present an accessibility statement if you are required to in your region.
+    </p>
+
+    <p>
+        Use the Django admin manager to control who can view this plugin. Ensure that users in the Guest group have read access to this plugin to make it visible to people not login in.
     </p>
 </div>

--- a/arches_her/templates/views/components/plugins/accessibility.htm
+++ b/arches_her/templates/views/components/plugins/accessibility.htm
@@ -1,11 +1,14 @@
 {% load i18n %}
-
 <div class="accessibility-statement">
-    <h2>Accessibility statement - IN DEVELOPMENT</h2>
+    <h2 class="">Accessibility statement - Plugin</h2>
     <p>
-        This is the default text for this application's accessibility statement.
+        <strong>[THIS CONTENT IS NOT AN ACCESSIBILITY STATEMENT]</strong>
     </p>
     <p>
-        An official note on the creation of accessibility statement will be added to this plugin.
+        You can use this plugin to present an accessibility statement if you are required to in your region.
+    </p>
+
+    <p>
+        Use the Django admin manager to control who can view this plugin. Ensure that users in the Guest group have read access to this plugin to make it visible to people not login in.
     </p>
 </div>


### PR DESCRIPTION
Simplified the accessibility plug-in content message and added some basic styling to allow the guidance to render better.

Imports the css to the project css.

fixes #1171 #1159 