### PR TITLE
Hides map submit buttons when in workflows

### DIFF
--- a/arches_her/media/css/project.css
+++ b/arches_her/media/css/project.css
@@ -807,6 +807,10 @@ table.report-tabular-card {
     margin-top: 10px;
 }
 
+.tabbed-workflow-step-body .workbench-card-sidepanel .install-buttons {
+    display: none;
+}
+
 .report-tabular-card td {
     padding: 4px;
     color: #a3a4a4;


### PR DESCRIPTION
Fixes issue #1169 

Stops workflow steps that have a map editing component from showing the install buttons at the bottom. The data submission function is handled by the Next/Previous Step and the complete workflow buttons.

![image](https://github.com/archesproject/arches-her/assets/25295526/7be47295-27a1-40f2-839c-3e37b843f37e)
![image](https://github.com/archesproject/arches-her/assets/25295526/27e0fc75-523f-4bc8-b8c8-cbae2f5944a1)
