### PR TITLE
Overlapping top level and search side panels

### DIFF
--- a/arches_her/media/css/project.css
+++ b/arches_her/media/css/project.css
@@ -1009,3 +1009,16 @@ span.rp-tile-title {
 .ep-edits {
     z-index: 12000;
 }
+
+/* Makes side panels cover the whole height of the page when the UI stacks in mobile mode */
+.ep-help-panel{
+    height: 100%;
+}
+
+.ep-edits-panel{
+    height: 100%;
+}
+
+.ep-notifs-panel{
+    height: 100%;
+}

--- a/arches_her/media/css/project.css
+++ b/arches_her/media/css/project.css
@@ -994,3 +994,18 @@ span.rp-tile-title {
     height: 100%;
     padding: 0px;
 }
+
+
+/* STOPS top level side panels being obscured by search filter popups in search*/
+
+.ep-notifs {
+    z-index: 12000;
+}
+
+.ep-help {
+    z-index: 12000;
+}
+
+.ep-edits {
+    z-index: 12000;
+}


### PR DESCRIPTION
Fixes #1162.  Also see #1180 which mentions the height issue.

Changes the z-index and height of the Notification, help, and provisional edit side panels of the basemanager so that they are not obscured by the search popups.

This might be a core issue, but applying the fix here for now.