### PR TITLE
Change Area Land Use Classification nodegroup cardinality

### DIFF
--- a/arches_her/pkg/graphs/resource_models/Area.json
+++ b/arches_her/pkg/graphs/resource_models/Area.json
@@ -13084,7 +13084,7 @@
                     "parentnodegroup_id": null
                 },
                 {
-                    "cardinality": "1",
+                    "cardinality": "n",
                     "legacygroupid": null,
                     "nodegroupid": "d17a5392-28cd-11eb-9b38-f875a44e0e11",
                     "parentnodegroup_id": "d17a538f-28cd-11eb-ab77-f875a44e0e11"


### PR DESCRIPTION
Changes cardinality of Land Use Classification in the Area resource model from "1" to "n" to match the Monument model.

Fixes #1194 

@Philbox interested in your thoughts on this - can an Area resource have multiple Land Use Classification tiles in the same way as Mons?

@aj-he I've targeted this at the upgrade branch for now as it isn't a big change, but it can be changed to target the dev branch for after the launch.