### PR TITLE
Details tab overflowing

### DIFF
--- a/arches_her/media/css/project.css
+++ b/arches_her/media/css/project.css
@@ -2,6 +2,14 @@
 @import url(./bng-filter.css);
 @import url(./accessibility-plugin.css);
 
+header {
+    max-width: calc(100vw - 50px);
+}
+
+.search-inline-filters {
+    justify-content: left;
+}
+
 .workflow-panel.navbarclosed {
     min-width: 50px;
     width: 50px;

--- a/arches_her/media/css/report_templates.css
+++ b/arches_her/media/css/report_templates.css
@@ -959,12 +959,4 @@ table.dataTable.dtr-inline.collapsed>tbody>tr>td:first-child,table.dataTable.dtr
         margin: 0;
         padding: 10px 30px;
     }
-
-    /*article.main-search-container .search-map-container .tab-content {
-        height: 100%;
-    }
-
-    article.main-search-container .search-map-container .tab-content .tab-content-component {
-        height: 100%;
-    }*/
 }

--- a/arches_her/media/css/report_templates.css
+++ b/arches_her/media/css/report_templates.css
@@ -5,6 +5,11 @@
     display: flex;
     flex: 1;
     flex-direction: column;
+    overflow-y: auto !important;
+}
+
+.resource-component-abstract.reportSummary {
+    overflow-y: inherit !important;
 }
 
 .aher-tabbed-report .fa-angle-double-right {

--- a/arches_her/media/css/report_templates.css
+++ b/arches_her/media/css/report_templates.css
@@ -861,12 +861,9 @@ a.aher-block-value-url {
 }
 
 .aher-summary-report-header {
-    height: 50px;
+    min-height: 50px;
     background: #fff;
-    position: fixed;
-    top: 101px;
     width: 100%;
-    margin-bottom: 60px;
     z-index: 10;
 }
 
@@ -881,7 +878,10 @@ a.aher-block-value-url {
 
 .model-summary-report {
     background: #fff;
-    padding: 55px 30px 30px 30px;
+    padding: 30px;
+    min-height: calc(100vh - 100px);
+    border: 0;
+    outline: none;
 }
 
 .graph-designer .aher-report-toolbar {
@@ -928,15 +928,38 @@ table.dataTable.dtr-inline.collapsed>tbody>tr>td:first-child,table.dataTable.dtr
 .resource-report-abstract-container {
     height: calc(100vh - 50px);
     min-height: calc(100vh - 50px);
-    width: calc(100vw - 50px);
 }
 
 .resource-report-abstract-container footer {
     display: none !important;
 }
 
+.search-result-details {
+    height: auto;
+}
+
+.tab-pane.active {
+    outline: 0!important;
+}
+
 @media screen and (max-width: 1024px){
     .resource-report-abstract-container {
         height: auto;
     }
+
+    .search-result-details .resource-report {
+        display: block;
+    }
+    .aher-summary-report-title {
+        margin: 0;
+        padding: 10px 30px;
+    }
+
+    /*article.main-search-container .search-map-container .tab-content {
+        height: 100%;
+    }
+
+    article.main-search-container .search-map-container .tab-content .tab-content-component {
+        height: 100%;
+    }*/
 }

--- a/arches_her/templates/views/components/resource-report-abstract.htm
+++ b/arches_her/templates/views/components/resource-report-abstract.htm
@@ -1,0 +1,43 @@
+{% load static %}
+{% load template_tags %}
+{% load i18n %}
+
+<!--ko if: loading() -->
+<div class='loading-mask'></div>
+<!--/ko-->
+<!-- ko ifnot: loading() -->
+<div class="resource-report-abstract-container">
+    <div class="resource-component-abstract"
+        data-bind='
+            component: { 
+                name: $data.template().componentname,
+                params: {
+                    report: $data.report(),
+                    summary: $data.summary,
+                    configForm: $data.configForm,
+                    configType: $data.configType,
+                }
+            },
+            css: { reportSummary: $data.summary }
+        '
+    ></div>
+
+    <!-- ko ifnot: $data.summary -->
+    <footer 
+        style="
+            background: #f8f8f8; 
+            display: flex;
+            height: 50px;
+            justify-content: space-between;
+            align-items: center;
+            padding: 0 20px;
+        "
+    >
+        <div data-bind="text: $root.translations.arches + ' ' + $data.version"></div>
+        <div>
+            <a href="http://archesproject.org" target="_blank">http://archesproject.org</a>
+        </div>
+    </footer>
+    <!--/ko-->
+</div>
+<!-- /ko -->


### PR DESCRIPTION
On the Search page, when selecting Details in the search results, the overflow was not working as expected. Also ensured that the normal Report was not affected by any css changes (height and overflow scrolling).

Fixes #1184 