### PR TITLE
Fixes editor tree error when trying to load child cards for the consultation location top level card

### DIFF
--- a/arches_her/templates/views/components/cards/default.htm
+++ b/arches_her/templates/views/components/cards/default.htm
@@ -1,6 +1,7 @@
 {% extends "views/components/cards/default.htm" %}
 {% load i18n %}
 
+<!-- ADDS HOTFIX FOR LOADING CONSULTATION LOCATION CHILD CARDS IN EDITOR TREE -->
 <!-- ko if: state === 'editor-tree' && self.card.model.visible() -->
 {% block editor_tree %}
 <li role="treeitem card-treeitem" class="jstree-node" data-bind="css: {'jstree-open': (card.tiles().length > 0 && card.expanded()), 'jstree-closed' : (card.tiles().length > 0 && !card.expanded()), 'jstree-leaf': card.tiles().length === 0, 'hide-background': !self.showGrid()}, scrollTo: card.scrollTo, container: '.resource-editor-tree'">
@@ -65,8 +66,9 @@
                         data: cards,
                         as: 'card'
                     }">
+                    <!-- HOTFIX ADDED TO COMPONENT NAME PROPERTY: was self.form.cardComponentLookup[SELF.card.model.component_id()].componentname-->
                     <!-- ko component: {
-                        name: self.form.cardComponentLookup[self.card.model.component_id()].componentname,
+                        name: self.form.cardComponentLookup[card.model.component_id()].componentname,
                         params: {
                             state: 'editor-tree',
                             card: card,

--- a/arches_her/templates/views/components/cards/default.htm
+++ b/arches_her/templates/views/components/cards/default.htm
@@ -1,6 +1,89 @@
 {% extends "views/components/cards/default.htm" %}
 {% load i18n %}
 
+<!-- ko if: state === 'editor-tree' && self.card.model.visible() -->
+{% block editor_tree %}
+<li role="treeitem card-treeitem" class="jstree-node" data-bind="css: {'jstree-open': (card.tiles().length > 0 && card.expanded()), 'jstree-closed' : (card.tiles().length > 0 && !card.expanded()), 'jstree-leaf': card.tiles().length === 0, 'hide-background': !self.showGrid()}, scrollTo: card.scrollTo, container: '.resource-editor-tree'">
+    <i class="jstree-icon" role="presentation" data-bind="click: function(){card.expanded(!card.expanded())}, css: {'jstree-ocl': self.showGrid}"></i>
+    <a class="jstree-anchor" href="#" tabindex="-1" data-bind="css:{'filtered': card.highlight(), 'jstree-clicked': card.selected, 'child-selected': card.isChildSelected(), 'func-node': card.isFuncNode(),'unsaved-edit': card.isDirty() === true}, event: {
+        mousedown: function(d, e) {
+            e.stopPropagation();
+            self.card.canAdd() ? self.card.selected(true) : self.card.tiles()[0].selected(true);
+        }
+    }">
+        <!-- ko if: !self.card.isFuncNode() -->
+        <i class="fa fa-file-o" role="presentation" data-bind="css:{'filtered': self.card.highlight(), 'has-provisional-edits fa-file': self.card.doesChildHaveProvisionalEdits()}"></i>
+        <!-- /ko -->
+        <!-- ko if: self.card.isFuncNode() -->
+        <i class="fa fa-code" role="presentation" data-bind="css:{'filtered': self.card.highlight(), 'has-provisional-edits fa-file': self.card.doesChildHaveProvisionalEdits()}"></i>
+        <!-- /ko -->
+        <span style="padding-right: 5px;" data-bind="text: self.card.model.name"></span>
+        <!-- ko if: self.card.canAdd() -->
+        <i class="fa fa-plus-circle add-new-tile" role="presentation" data-bind="css:{'jstree-clicked': self.card.selected}, click: function(){self.card.showForm(true);}, clickBubble: false" data-toggle="tooltip" data-original-title="$root.translations.addGnu"></i>
+        <!-- /ko -->
+    </a>
+    <ul class="jstree-children" aria-expanded="true">
+        <div data-bind="sortable: {
+            data: self.card.tiles,
+            options: {
+                start: self.startDrag
+            },
+            beforeMove: self.beforeMove,
+            afterMove: self.card.reorderTiles
+        }">
+            <li role="treeitem" class="jstree-node" data-bind="css: {'jstree-open': (cards.length > 0 && expanded), 'jstree-closed' : (cards.length > 0 && !expanded()), 'jstree-leaf': cards.length === 0, 'hide-background': !self.showGrid()}, event: {'dragstart': function () { console.log('dragging...') }}">
+                <i class="jstree-icon" role="presentation" data-bind="click: function(){expanded(!expanded())}, css: {'jstree-ocl': self.showGrid}"></i>
+                <a class="jstree-anchor" href="#" tabindex="-1" data-bind="click: function () { self.form.selection($data);}, css:{'jstree-clicked': selected, 'child-selected': isChildSelected(), 'filtered-leaf': card.highlight(), 'unsaved-edit': !!$data.dirty()}">
+                    <i class="fa " role="presentation" data-bind="css:{'has-provisional-edits': doesChildHaveProvisionalEdits() || $data.hasprovisionaledits(),'fa-pencil':$data.dirty()===true,'fa-file':!$data.dirty()}"></i>
+                    <strong style="margin-right: 10px;">
+                        {% block editor_tree_node_content %}
+                        <!-- ko if: self.card.widgets().length > 0 && self.card.widgets()[0].visible -->
+                        <span data-bind="text: self.card.widgets()[0].label || self.card.model.name"></span>:
+                        <div style="display: inline;" data-bind="component: {
+                            name: self.form.widgetLookup[self.card.widgets()[0].widget_id()].name,
+                            params: {
+                                tile: $data,
+                                node: self.form.nodeLookup[card.widgets()[0].node_id()],
+                                config: self.form.widgetLookup[card.widgets()[0].widget_id()].config,
+                                label: self.form.widgetLookup[card.widgets()[0].widget_id()].label,
+                                inResourceEditor: self.inResourceEditor,
+                                value: $data.data[card.widgets()[0].node_id()],
+                                type: 'resource-editor',
+                                state: 'display_value',
+                                disabled: !self.card.isWritable && !self.preview
+                            }
+                        }"></div>
+                        <!-- /ko -->
+                        <!-- ko if: self.card.widgets().length === 0 || !self.card.widgets()[0].visible -->
+                        <span data-bind="text: self.card.model.name"></span>
+                        <!-- /ko -->
+                        {% endblock editor_tree_node_content %}
+                    </strong>
+                </a>
+                <!-- ko if: cards.length > 0 && self.card.expanded() -->
+                <ul class="jstree-children" aria-expanded="true" data-bind="foreach: {
+                        data: cards,
+                        as: 'card'
+                    }">
+                    <!-- ko component: {
+                        name: self.form.cardComponentLookup[self.card.model.component_id()].componentname,
+                        params: {
+                            state: 'editor-tree',
+                            card: card,
+                            tile: null,
+                            loading: self.loading,
+                            form: self.form,
+                            pageVm: $root
+                        }
+                    } --> <!-- /ko -->
+                </ul>
+                <!-- /ko -->
+            </li>
+        </div>
+    </ul>
+</li>
+{% endblock editor_tree %}
+<!-- /ko -->
 
 {% block report %}
 <div data-bind="css: {'print-hide': !reportExpanded()}">


### PR DESCRIPTION
Provides a fix for the issue in core where the Consultation Location card breaks the rendering of child cards in the editor tree #1186 .

The problem is that as the children where loaded, they were being passed the parent component name. This was an issue where they were different (related-resource-map card with default card children.

This will need to be fixed in core.