### PR TITLE
Long search tags not wrapping

### DIFF
--- a/arches_her/media/css/project.css
+++ b/arches_her/media/css/project.css
@@ -1007,6 +1007,8 @@ span.rp-tile-title {
     padding: 0px;
 }
 
+/* Ensures search tags gracefully display any text overflowing */
+
 .term-search-filter .select2-container--default .select2-selection--multiple .select2-selection__choice {
     max-width: 96%;
     text-overflow: ellipsis;
@@ -1033,6 +1035,7 @@ span.rp-tile-title {
 }
 
 /* Makes side panels cover the whole height of the page when the UI stacks in mobile mode */
+
 .ep-help-panel{
     height: 100%;
 }

--- a/arches_her/media/css/project.css
+++ b/arches_her/media/css/project.css
@@ -1007,6 +1007,16 @@ span.rp-tile-title {
     padding: 0px;
 }
 
+.term-search-filter .select2-container--default .select2-selection--multiple .select2-selection__choice {
+    max-width: 96%;
+    text-overflow: ellipsis;
+}
+
+.term-search-filter .select2-container--default .select2-selection--multiple .select2-selection__choice button.search-tag {
+    max-width: 98%;
+    text-overflow: ellipsis;
+    overflow: hidden;
+}
 
 /* STOPS top level side panels being obscured by search filter popups in search*/
 


### PR DESCRIPTION
Upon further investigation, it's not going to be wise to cause wrapping of the search tags as it breaks the containing elements. selectWoo is used throughout the site and it's not worth causing a huge amount of work checking for various situations its being used in etc. Best option was to display ellipses indicating there is more text, and this is the selectWoo default method.

Fixes #1164 