### PR TITLE
#1221 Change reference to Delete in Workflow final step

### DIFF
--- a/arches_her/media/js/views/components/plugins/application-area.js
+++ b/arches_her/media/js/views/components/plugins/application-area.js
@@ -185,7 +185,7 @@ define([
                     ],
                     informationboxdata: {
                         heading: 'Workflow Complete: Review your work',
-                        text: 'Please review the summary information. You can go back to a previous step to make changes or "Quit Workflow" to discard your changes and start over',
+                        text: 'Please review the summary information. You can go back to a previous step to make changes or "Delete" to discard your changes and start over',
                     }
                 }
             ];

--- a/arches_her/media/js/views/components/plugins/communication-workflow.js
+++ b/arches_her/media/js/views/components/plugins/communication-workflow.js
@@ -180,7 +180,7 @@ define([
                     parenttileid: null,
                     informationboxdata: {
                         heading: 'Workflow Complete: Review your work',
-                        text: 'Please review the summary information. You can go back to a previous step to make changes or "Quit Workflow" to discard your changes and start over',
+                        text: 'Please review the summary information. You can go back to a previous step to make changes or "Delete" to discard your changes and start over',
                     }
                 }
             ];

--- a/arches_her/media/js/views/components/plugins/consultation-workflow.js
+++ b/arches_her/media/js/views/components/plugins/consultation-workflow.js
@@ -187,7 +187,7 @@ define([
                     ],
                     informationboxdata: {
                         heading: 'Workflow Complete: Review your work',
-                        text: 'Please review the summary information. You can go back to a previous step to make changes or "Quit Workflow" to discard your changes and start over',
+                        text: 'Please review the summary information. You can go back to a previous step to make changes or "Delete" to discard your changes and start over',
                     }
                 },
             ];

--- a/arches_her/media/js/views/components/plugins/site-visit.js
+++ b/arches_her/media/js/views/components/plugins/site-visit.js
@@ -148,7 +148,7 @@ define([
                     name: 'site-visit-complete',
                     informationboxdata: {
                         heading: 'Workflow Complete: Review your work',
-                        text: 'Please review the summary information. You can go back to a previous step to make changes or "Quit Workflow" to discard your changes and start over',
+                        text: 'Please review the summary information. You can go back to a previous step to make changes or "Delete" to discard your changes and start over',
                     },
                     layoutSections: [
                         {


### PR DESCRIPTION
Fixes #1221 

Changes the reference of 'Quit Workflow' to 'Delete' in the final step summary page of the following workflows:

- Application Area
- Communication
- Consultation
- Site Visit