### PR TITLE
Add Record Type node to Monument and Area graphs

### DIFF
--- a/arches_her/pkg/graphs/branches/Record Type.json
+++ b/arches_her/pkg/graphs/branches/Record Type.json
@@ -1,7 +1,7 @@
 {
     "graph": [
         {
-            "author": "",
+            "author": "Samuel Scandrett - Knowledge Integration",
             "cards": [
                 {
                     "active": true,

--- a/arches_her/pkg/graphs/branches/Record Type.json
+++ b/arches_her/pkg/graphs/branches/Record Type.json
@@ -1,0 +1,146 @@
+{
+    "graph": [
+        {
+            "author": "",
+            "cards": [
+                {
+                    "active": true,
+                    "cardid": "02956e76-03d2-11ef-89f3-3736dd7ed53f",
+                    "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
+                    "config": null,
+                    "constraints": [],
+                    "cssclass": null,
+                    "description": "",
+                    "graph_id": "02956e74-03d2-11ef-89f3-3736dd7ed53f",
+                    "helpenabled": false,
+                    "helptext": null,
+                    "helptitle": null,
+                    "instructions": null,
+                    "is_editable": true,
+                    "name": "Record Type",
+                    "nodegroup_id": "02956e75-03d2-11ef-89f3-3736dd7ed53f",
+                    "sortorder": null,
+                    "visible": true
+                }
+            ],
+            "cards_x_nodes_x_widgets": [
+                {
+                    "card_id": "02956e76-03d2-11ef-89f3-3736dd7ed53f",
+                    "config": {
+                        "defaultValue": "",
+                        "label": "Record Type",
+                        "placeholder": "Select an option"
+                    },
+                    "id": "02956e77-03d2-11ef-89f3-3736dd7ed53f",
+                    "label": "Record Type",
+                    "node_id": "02956e75-03d2-11ef-89f3-3736dd7ed53f",
+                    "sortorder": 0,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000015"
+                }
+            ],
+            "color": "rgba(59,84,33,1)",
+            "config": {},
+            "deploymentdate": null,
+            "deploymentfile": null,
+            "description": {
+                "en": ""
+            },
+            "edges": [],
+            "functions_x_graphs": [],
+            "graphid": "02956e74-03d2-11ef-89f3-3736dd7ed53f",
+            "iconclass": "fa fa-bank",
+            "is_editable": true,
+            "isactive": true,
+            "isresource": false,
+            "jsonldcontext": null,
+            "name": {
+                "en": "Record Type"
+            },
+            "nodegroups": [
+                {
+                    "cardinality": "1",
+                    "legacygroupid": null,
+                    "nodegroupid": "02956e75-03d2-11ef-89f3-3736dd7ed53f",
+                    "parentnodegroup_id": null
+                }
+            ],
+            "nodes": [
+                {
+                    "alias": "record_type",
+                    "config": {
+                        "options": [
+                            {
+                                "id": "534aefb3-b5c2-45a5-a1c8-b96da19f4e93",
+                                "selected": false,
+                                "text": "Monument"
+                            },
+                            {
+                                "id": "5e5d6f01-fcd9-4ba0-b86d-564456a520b2",
+                                "selected": false,
+                                "text": "Building"
+                            }
+                        ]
+                    },
+                    "datatype": "domain-value",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "02956e74-03d2-11ef-89f3-3736dd7ed53f",
+                    "hascustomalias": false,
+                    "is_collector": true,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": true,
+                    "name": "Record Type",
+                    "nodegroup_id": "02956e75-03d2-11ef-89f3-3736dd7ed53f",
+                    "nodeid": "02956e75-03d2-11ef-89f3-3736dd7ed53f",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "",
+                    "sortorder": 0
+                }
+            ],
+            "ontology_id": "e6e8db47-2ccf-11e6-927e-b8f6b115d7dd",
+            "relatable_resource_model_ids": [],
+            "resource_2_resource_constraints": [],
+            "root": {
+                "alias": "record_type",
+                "config": {
+                    "options": [
+                        {
+                            "id": "534aefb3-b5c2-45a5-a1c8-b96da19f4e93",
+                            "selected": false,
+                            "text": "Monument"
+                        },
+                        {
+                            "id": "5e5d6f01-fcd9-4ba0-b86d-564456a520b2",
+                            "selected": false,
+                            "text": "Building"
+                        }
+                    ]
+                },
+                "datatype": "domain-value",
+                "description": null,
+                "exportable": false,
+                "fieldname": null,
+                "graph_id": "02956e74-03d2-11ef-89f3-3736dd7ed53f",
+                "hascustomalias": false,
+                "is_collector": true,
+                "isrequired": false,
+                "issearchable": true,
+                "istopnode": true,
+                "name": "Record Type",
+                "nodegroup_id": "02956e75-03d2-11ef-89f3-3736dd7ed53f",
+                "nodeid": "02956e75-03d2-11ef-89f3-3736dd7ed53f",
+                "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                "sortorder": 0
+            },
+            "slug": null,
+            "subtitle": {
+                "en": ""
+            },
+            "template_id": "50000000-0000-0000-0000-000000000001",
+            "version": ""
+        }
+    ]
+}

--- a/arches_her/pkg/graphs/resource_models/Area.json
+++ b/arches_her/pkg/graphs/resource_models/Area.json
@@ -209,6 +209,33 @@
                 },
                 {
                     "active": true,
+                    "cardid": "45f69046-03d2-11ef-89f3-3736dd7ed53f",
+                    "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
+                    "config": null,
+                    "constraints": [],
+                    "cssclass": null,
+                    "description": "",
+                    "graph_id": "979aaf0b-7042-11ea-9674-287fcf6a5e72",
+                    "helpenabled": false,
+                    "helptext": {
+                        "en": null
+                    },
+                    "helptitle": {
+                        "en": null
+                    },
+                    "instructions": {
+                        "en": null
+                    },
+                    "is_editable": true,
+                    "name": {
+                        "en": "Record Type"
+                    },
+                    "nodegroup_id": "45f69045-03d2-11ef-89f3-3736dd7ed53f",
+                    "sortorder": 21,
+                    "visible": true
+                },
+                {
+                    "active": true,
                     "cardid": "64be0913-3ee5-11eb-9d04-f875a44e0e11",
                     "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
                     "config": null,
@@ -2272,6 +2299,32 @@
                     "sortorder": 7,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
+                },
+                {
+                    "card_id": "45f69046-03d2-11ef-89f3-3736dd7ed53f",
+                    "config": {
+                        "defaultValue": {
+                            "en": {
+                                "direction": "ltr",
+                                "value": ""
+                            }
+                        },
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "Record Type",
+                        "placeholder": {
+                            "en": "Select an option"
+                        }
+                    },
+                    "id": "45f69047-03d2-11ef-89f3-3736dd7ed53f",
+                    "label": {
+                        "en": "Record Type"
+                    },
+                    "node_id": "45f69045-03d2-11ef-89f3-3736dd7ed53f",
+                    "sortorder": 0,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000015"
                 },
                 {
                     "card_id": "b334ddde-4e87-11eb-ab31-f875a44e0e11",
@@ -9604,6 +9657,15 @@
                 },
                 {
                     "description": null,
+                    "domainnode_id": "979aaf0a-7042-11ea-8a93-287fcf6a5e72",
+                    "edgeid": "320df724-be18-40b2-ae32-ead3dddc7824",
+                    "graph_id": "979aaf0b-7042-11ea-9674-287fcf6a5e72",
+                    "name": null,
+                    "ontologyproperty": "http://www.ics.forth.gr/isl/CRMdig/L54i_is_same-as",
+                    "rangenode_id": "45f69045-03d2-11ef-89f3-3736dd7ed53f"
+                },
+                {
+                    "description": null,
                     "domainnode_id": "64be56e1-3ee5-11eb-b764-f875a44e0e11",
                     "edgeid": "64c18b00-3ee5-11eb-9287-f875a44e0e11",
                     "graph_id": "979aaf0b-7042-11ea-9674-287fcf6a5e72",
@@ -12942,6 +13004,12 @@
                 {
                     "cardinality": "1",
                     "legacygroupid": null,
+                    "nodegroupid": "45f69045-03d2-11ef-89f3-3736dd7ed53f",
+                    "parentnodegroup_id": null
+                },
+                {
+                    "cardinality": "1",
+                    "legacygroupid": null,
                     "nodegroupid": "64be0911-3ee5-11eb-87f4-f875a44e0e11",
                     "parentnodegroup_id": "64be2fdb-3ee5-11eb-9565-f875a44e0e11"
                 },
@@ -14629,6 +14697,43 @@
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P104_is_subject_to",
                     "sortorder": 0,
                     "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "record_type",
+                    "config": {
+                        "options": [
+                            {
+                                "id": "534aefb3-b5c2-45a5-a1c8-b96da19f4e93",
+                                "selected": false,
+                                "text": {
+                                    "en": "Monument"
+                                }
+                            },
+                            {
+                                "id": "5e5d6f01-fcd9-4ba0-b86d-564456a520b2",
+                                "selected": false,
+                                "text": {
+                                    "en": "Building"
+                                }
+                            }
+                        ]
+                    },
+                    "datatype": "domain-value",
+                    "description": "",
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "979aaf0b-7042-11ea-9674-287fcf6a5e72",
+                    "hascustomalias": false,
+                    "is_collector": true,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Record Type",
+                    "nodegroup_id": "45f69045-03d2-11ef-89f3-3736dd7ed53f",
+                    "nodeid": "45f69045-03d2-11ef-89f3-3736dd7ed53f",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.ics.forth.gr/isl/CRMdig/L54i_is_same-as",
+                    "sortorder": 0
                 },
                 {
                     "alias": "coordinate_system",

--- a/arches_her/pkg/graphs/resource_models/Monument.json
+++ b/arches_her/pkg/graphs/resource_models/Monument.json
@@ -1015,6 +1015,33 @@
                 },
                 {
                     "active": true,
+                    "cardid": "ab469588-2671-4d7c-8b86-ae28694714b7",
+                    "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
+                    "config": null,
+                    "constraints": [],
+                    "cssclass": null,
+                    "description": null,
+                    "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
+                    "helpenabled": false,
+                    "helptext": {
+                        "en": null
+                    },
+                    "helptitle": {
+                        "en": null
+                    },
+                    "instructions": {
+                        "en": null
+                    },
+                    "is_editable": true,
+                    "name": {
+                        "en": "Record Type"
+                    },
+                    "nodegroup_id": "6ed65604-03d0-11ef-89f3-3736dd7ed53f",
+                    "sortorder": 21,
+                    "visible": true
+                },
+                {
+                    "active": true,
                     "cardid": "b2133e65-efdc-11eb-992a-a87eeabdefba",
                     "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
                     "config": null,
@@ -9230,6 +9257,27 @@
                     "widget_id": "10000000-0000-0000-0000-000000000002"
                 },
                 {
+                    "card_id": "ab469588-2671-4d7c-8b86-ae28694714b7",
+                    "config": {
+                        "defaultValue": "",
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "Record Type",
+                        "placeholder": {
+                            "en": "Select an option"
+                        }
+                    },
+                    "id": "c9341d94-1c66-403c-9b73-3908713fe7a1",
+                    "label": {
+                        "en": "Record Type"
+                    },
+                    "node_id": "6ed65604-03d0-11ef-89f3-3736dd7ed53f",
+                    "sortorder": 0,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000015"
+                },
+                {
                     "card_id": "e0991c1d-51b4-11eb-a935-f875a44e0e11",
                     "config": {
                         "defaultResourceInstance": [],
@@ -9790,6 +9838,15 @@
                     "name": null,
                     "ontologyproperty": "http://www.ics.forth.gr/isl/CRMsci/O18i_was_altered_by",
                     "rangenode_id": "55d6a53e-049c-11eb-8618-f875a44e0e11"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "076f9380-7b00-11e9-88c8-80000b44d1d9",
+                    "edgeid": "5d9080ac-6624-40a0-a09c-fc3e4b91eecd",
+                    "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "6ed65604-03d0-11ef-89f3-3736dd7ed53f"
                 },
                 {
                     "description": null,
@@ -13493,6 +13550,12 @@
                     "parentnodegroup_id": null
                 },
                 {
+                    "cardinality": "1",
+                    "legacygroupid": null,
+                    "nodegroupid": "6ed65604-03d0-11ef-89f3-3736dd7ed53f",
+                    "parentnodegroup_id": null
+                },
+                {
                     "cardinality": "n",
                     "legacygroupid": null,
                     "nodegroupid": "77e8f287-efdc-11eb-a790-a87eeabdefba",
@@ -16890,6 +16953,43 @@
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
                     "sortorder": 0,
                     "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "record_type",
+                    "config": {
+                        "options": [
+                            {
+                                "id": "534aefb3-b5c2-45a5-a1c8-b96da19f4e93",
+                                "selected": false,
+                                "text": {
+                                    "en": "Monument"
+                                }
+                            },
+                            {
+                                "id": "5e5d6f01-fcd9-4ba0-b86d-564456a520b2",
+                                "selected": false,
+                                "text": {
+                                    "en": "Building"
+                                }
+                            }
+                        ]
+                    },
+                    "datatype": "domain-value",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
+                    "hascustomalias": false,
+                    "is_collector": true,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Record Type",
+                    "nodegroup_id": "6ed65604-03d0-11ef-89f3-3736dd7ed53f",
+                    "nodeid": "6ed65604-03d0-11ef-89f3-3736dd7ed53f",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0
                 },
                 {
                     "alias": "construction_phases",


### PR DESCRIPTION
#1227 

Adds a "Record Type" node in the Monument and Areas models with datatype domain-value and values of "Monument" and "Building".

![image](https://github.com/archesproject/arches-her/assets/119508494/dcfb8b0a-00c0-452f-a9dd-6e23bc25468b)
