### PR TITLE
QA and Resource Type dropdowns right alignment

### DIFF
--- a/arches_her/media/css/project.css
+++ b/arches_her/media/css/project.css
@@ -21,7 +21,7 @@ header {
 }
 
 .search-inline-filters {
-    justify-content: left;
+    justify-content: right;
 }
 
 .workflow-panel.navbarclosed {

--- a/arches_her/media/css/project.css
+++ b/arches_her/media/css/project.css
@@ -20,10 +20,6 @@ header {
     max-width: calc(100vw - 50px);
 }
 
-.search-inline-filters {
-    justify-content: right;
-}
-
 .workflow-panel.navbarclosed {
     min-width: 50px;
     width: 50px;


### PR DESCRIPTION
Ensure QA and Resource Type search dropdowns are right aligned instead of left. This also fixes an issue where, if left aligned, the dropdown contents get clipped on the left and you cant see everything you should.

Fixes #1217 