### PR TITLE
Add skip to content to index page

### DIFF
--- a/arches_her/media/css/_project-variables.scss
+++ b/arches_her/media/css/_project-variables.scss
@@ -13,3 +13,5 @@ $footer-text: #FFF;
 $footer-text-hint: #000;
 $footer-top-bg: #062647;
 $footer-bottom-bg: #041B33;
+$skiptocontent-link: #000;
+$skiptocontent-bg: #fae619;

--- a/arches_her/media/css/project.scss
+++ b/arches_her/media/css/project.scss
@@ -20,11 +20,41 @@ body {
 	font-weight: 300;
 	overflow-x: hidden;
 	min-width: 100vw;
-	a {
+
+    a {
 		&:focus {
 			outline: 2px solid $focus-outline !important;
 		}
 	}
+    #skip-link-holder {
+        a, a:link, a:visited {
+            color: $skiptocontent-link;
+            background-color: $skiptocontent-bg;
+            font-weight: bold;
+            text-decoration: none;
+            padding: 10px;
+            text-align: center;
+            outline: none !important;
+            max-height: 38px;
+            display: block;
+            width: 100%;
+            position: fixed;
+            top: -38px;
+            left: 0;
+            z-index: 10001;
+        }
+        a:focus, a:active {
+            text-decoration: underline !important;
+            left: 0;
+            top: 0;
+            z-index: 10000000;
+        }
+    }
+    #skip-target-holder {
+        position: absolute;
+        top: -38px;
+        left: 0;
+    }
 	input {
 		&:focus {
 			outline: 2px solid $focus-outline !important;

--- a/arches_her/templates/index.htm
+++ b/arches_her/templates/index.htm
@@ -64,6 +64,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     <script src="{% webpack_static 'node_modules/requirejs/require.js' %}"></script>
     {% include 'javascript.htm' %}
 
+    <div id="skip-link-holder"><a id="skip-link" href="#skiptocontent">{% trans "Skip to Content" %}</a></div>
+
     <!--=== Header ===-->
     <header>
         <div class="navbar">
@@ -131,6 +133,11 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     <!--=== End Header ===-->
 
     <main>
+        <p id="skip-target-holder">
+            <a id="skiptocontent" name="skiptocontent" class="skip" tabindex="-1" aria-label="{% trans "Skip to Content" %}">
+                {% trans "Skip to Content" %}
+            </a>
+        </p>
         <div class="container">
             <div class="row featurette1">
                 <div class="featurette1-left-container">


### PR DESCRIPTION
To fix an accessibility testing issue raised re no bypass block on the homepage, these changes will add the "skip to content" feature, upon first tab press. This will bypass the top menu items.

It's worth noting that I've had to use the trans tags for the text, as the $root.translations method isn't available on the index page.

fixes #1240