### PR TITLE
Fixes contrast issue for codemirror in aher tabbed reports

### DIFF
--- a/arches_her/media/css/report_templates.css
+++ b/arches_her/media/css/report_templates.css
@@ -298,6 +298,10 @@ i.toggle:hover {
     height: auto;
 }
 
+.aher-codemirror .CodeMirror-linenumber{
+    color: #545454;
+}
+
 .aher-table tr {
     height: 33px;
     border-top: 1px solid #ddd;


### PR DESCRIPTION
The line numbers in codemirror for the JSON report tabbed was not compliant. Changed to provide +7 AAA color contrast.

![image](https://github.com/user-attachments/assets/0368b531-47dd-4c0d-b19a-536c0ab638b1)

Fixes #1263 contrast issue