### PR TITLE
#1264 Aria Label and Empty Link Accessibility Errors

### DIFF
--- a/arches_her/media/js/utils/report.js
+++ b/arches_her/media/js/utils/report.js
@@ -113,7 +113,7 @@ define([
             paging: false,
             searching: false,
             scrollCollapse: true,
-            info: false,
+            info: true,
             columnDefs: [{
                 orderable: false,
                 targets: -1,
@@ -147,6 +147,13 @@ define([
                 if(tile){
                     tile.selected(true);
                 }
+            }
+        },
+
+        // Can be used to check if current page is in report mode or resource manager mode
+        checkCardsAvailable: function(cards){
+            if(Object.keys(cards).length > 0){
+                return true;
             }
         },
 

--- a/arches_her/templates/views/components/reports/activity.htm
+++ b/arches_her/templates/views/components/reports/activity.htm
@@ -103,8 +103,9 @@
             <div class="aher-report-page" data-bind="if: activeSection() === 'archive'">
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title"><i tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.activityArchive)}, css: {'fa-angle-double-right': visible.activityArchive(), 'fa-angle-double-up': !visible.activityArchive()}"  class="fa toggle"></i> {% trans "Activity Archive Material" %}</h2>
-                    <a href="#" data-bind="{if: cards.activityArchive, click: function(){addNewTile(cards.activityArchive)}}" class="aher-report-a"><i class="fa fa-mail-reply"></i> {% trans "Add Archive Material" %}</a>
-
+                    <!-- ko if: checkCardsAvailable($data.cards) -->
+                        <a href="#" data-bind="{if: cards.activityArchive, click: function(){addNewTile(cards.activityArchive)}}" class="aher-report-a"><i class="fa fa-mail-reply"></i> {% trans "Add Archive Material" %}</a>
+                    <!-- /ko -->
                     <!-- Collapsible content -->
                     <div data-bind="visible: visible.activityArchive" class="aher-report-collapsible-container pad-lft">
 

--- a/arches_her/templates/views/components/reports/scenes/location.htm
+++ b/arches_her/templates/views/components/reports/scenes/location.htm
@@ -16,8 +16,10 @@
         <div class="aher-report-subsection">
             <div class="aher-report-subsection-container no-flex map-container">
                 <h3><i data-bind="css: {'fa-angle-double-right': visible.geometry(), 'fa-angle-double-up': !visible.geometry()}" class="fa toggle"></i> {% trans "Geometry " %}  <span data-bind="visible: observableValueSet([geometryShape])">(Shape type: <span data-bind="text: geometryShape"></span>)</span></h3>
-                <a href="#" class="aher-report-a" data-bind="{if: cards.locationGeometry, click: function(){addNewTile(cards.locationGeometry)}}"><i class="fa fa-mail-reply"></i> {% trans "Edit location" %}</a>
-                <div data-bind="if: visible.geometry">
+                <!-- ko if: checkCardsAvailable($parent.cards) -->
+                    <a href="#" class="aher-report-a" data-bind="{if: cards.locationGeometry, click: function(){addNewTile(cards.locationGeometry)}}"><i class="fa fa-mail-reply"></i> {% trans "Edit location" %}</a>
+                <!-- /ko -->
+                    <div data-bind="if: visible.geometry">
                     <div data-bind="component: {
                         name: 'views/components/reports/scenes/map',
                         params: {

--- a/arches_her/templates/views/components/reports/scenes/name.htm
+++ b/arches_her/templates/views/components/reports/scenes/name.htm
@@ -5,10 +5,12 @@
 {% block body %}
 <!-- ko ifnot: hideNames() -->
 <div data-bind="visible: !!dataConfig.name" class="aher-report-section">
-    <h2 class="aher-report-section-title"><i tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.names)}, css: {'fa-angle-double-right': visible.names(), 'fa-angle-double-up': !visible.names()}" class="fa toggle"></i> {% trans "Names" %}</h2>
-    <span data-bind="if: cards.name && (!names().length || cards.name.cardinality == 'n')">
-        <a class="aher-report-a" data-bind="click: function(){add(cards.name)}"><i class="fa fa-mail-reply"></i> {% trans "Add Name" %}</a>
-    </span>
+    <h2 class="aher-report-section-title"><i tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.names)}, css: {'fa-angle-double-right': visible.names(), 'fa-angle-double-up': !visible.names()}, attr: {'aria-expanded': visible.names() ? 'false' : 'true' }" class="fa toggle" aria-label="Expand/collapse Names section"></i> {% trans "Names" %}</h2>
+    <!-- ko if: checkCardsAvailable($parent.cards) -->
+        <span data-bind="if: cards.name && (!names().length || cards.name.cardinality == 'n')">
+            <a href="#" class="aher-report-a" data-bind="click: function(){add(cards.name)}"><i class="fa fa-mail-reply"></i> {% trans "Add Name" %}</a>
+        </span>
+    <!-- /ko -->
 
     <!-- Collapsible content -->
     <div data-bind="visible: visible.names" class="aher-report-collapsible-container pad-lft">
@@ -59,8 +61,11 @@
 <!-- External Reference -->
 <!-- ko ifnot: hideCrossReferences() -->
 <div data-bind="visible: !!dataConfig.xref" class="aher-report-section">
-    <h2 class="aher-report-section-title"><i tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.crossReferences)}, css: {'fa-angle-double-right': visible.crossReferences(), 'fa-angle-double-up': !visible.crossReferences()}" class="fa toggle"></i> {% trans "External Cross References" %}</h2>
-    <a href="#" data-bind="{if: cards.externalCrossReferences, click: function(){addNewTile(cards.externalCrossReferences)}}" class="aher-report-a"><i class="fa fa-mail-reply"></i> {% trans "Add Reference" %}</a>
+    <h2 class="aher-report-section-title"><i tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.crossReferences)}, css: {'fa-angle-double-right': visible.crossReferences(), 'fa-angle-double-up': !visible.crossReferences()}, attr: {'aria-expanded': visible.crossReferences() ? 'false' : 'true' }" class="fa toggle" aria-label="Expand/collapse External Cross References section"></i> {% trans "External Cross References" %}</h2>
+    
+    <!-- ko if: checkCardsAvailable($parent.cards) -->
+        <a href="#" data-bind="{if: cards.externalCrossReferences, click: function(){addNewTile(cards.externalCrossReferences)}}" class="aher-report-a"><i class="fa fa-mail-reply"></i> {% trans "Add Reference" %}</a>
+    <!-- /ko -->
 
     <!-- Collapsible content -->
     <div data-bind="visible: visible.crossReferences" class="aher-report-collapsible-container pad-lft">
@@ -118,11 +123,13 @@
 <!-- System Reference Numbers section -->
 <div class="aher-report-section">
     <h2 class="aher-report-section-title"><i tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.systemReferenceNumbers)}, css: {'fa-angle-double-right': visible.systemReferenceNumbers(), 'fa-angle-double-up': !visible.systemReferenceNumbers()}" class="fa toggle"></i> {% trans "System Reference Numbers" %}</h2>
-    <a href="#" data-bind="{if: cards.systemReferenceNumbers, click: function(){ addNewTile(cards.systemReferenceNumbers) }}" class="aher-report-a">
-        <i class="fa fa-mail-reply"></i>
-        <span data-bind="if: cards.systemReferenceNumbers.tiles().length">{% trans "Edit Identifier" %}</span>
-        <span data-bind="ifnot: cards.systemReferenceNumbers.tiles().length">{% trans "Add Identifier" %}</span>
-    </a>
+    <!-- ko if: checkCardsAvailable($parent.cards) -->
+        <a href="#" data-bind="{if: cards.systemReferenceNumbers, click: function(){ addNewTile(cards.systemReferenceNumbers) }}" class="aher-report-a">
+            <i class="fa fa-mail-reply"></i>
+            <span data-bind="if: cards.systemReferenceNumbers.tiles().length">{% trans "Edit Identifier" %}</span>
+            <span data-bind="ifnot: cards.systemReferenceNumbers.tiles().length">{% trans "Add Identifier" %}</span>
+        </a>
+    <!-- /ko -->
 
     <!-- Collapsible content -->
     <div data-bind="visible: visible.systemReferenceNumbers" class="aher-report-collapsible-container pad-lft">

--- a/arches_her/templates/views/components/reports/scenes/people.htm
+++ b/arches_her/templates/views/components/reports/scenes/people.htm
@@ -6,8 +6,9 @@
 <!-- Associated Actors -->
 <div class="aher-report-section">
     <h2 class="aher-report-section-title"><i tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.people)}, css: {'fa-angle-double-right': visible.people(), 'fa-angle-double-up': !visible.people()}" class="fa toggle"></i> {% trans "Associated People and Organizations" %}</h2>
-    <a href="#" data-bind="{if: cards.people, click: function(){addNewTile(cards.people)}}" class="aher-report-a"><i class="fa fa-mail-reply"></i> {% trans "Add People/Organizations" %}</a>
-
+    <!-- ko if: checkCardsAvailable($parent.cards) -->
+        <a href="#" data-bind="{if: cards.people, click: function(){addNewTile(cards.people)}}" class="aher-report-a"><i class="fa fa-mail-reply"></i> {% trans "Add People/Organizations" %}</a>
+    <!-- /ko -->
     <!-- Collapsible content -->
     <div data-bind="visible: visible.people" class="aher-report-collapsible-container pad-lft">
 


### PR DESCRIPTION
Fixes #1264 

- Set info in defaultTableConfig to true (set to false causes aria-describedby error).  This does mean "showing x to x of x entries" is visible beneath tables but perhaps this can be hidden visibly by styling in another PR (@phudson-he FYI)
- Creates a new function, checkCardsAvailable, in report.js which can be used to see if there are cards in the data or parent object; if there are then the user is in resource manager mode and if not then the user is in report mode
- Only displays the add/edit links if there are cards in the data or parent object, as checked using the checkCardsAvailable function (this stops the links from rendering in the code if the user is in the report view, thus fixing the Empty Link Accessibility errors)