### PR TITLE
Add Artefact Type Certainty node

### DIFF
--- a/arches_her/media/js/views/components/reports/scenes/classifications.js
+++ b/arches_her/media/js/views/components/reports/scenes/classifications.js
@@ -31,7 +31,7 @@ function(_, ko, arches, reportUtils, ClassificationsTemplate) {
 
             self.artefactProdTableConfiguration= {
                 ...self.defaultTableConfig,
-                columns: Array(13).fill(null)
+                columns: Array(14).fill(null)
             };
             // Components Table
             self.componentsTableConfig = {
@@ -171,6 +171,7 @@ function(_, ko, arches, reportUtils, ClassificationsTemplate) {
                         const phaseDescription = self.getNodeValue(node, 'phase classification', 'phase classification description', 'phase description');
                         const phaseEvidence = self.getNodeValue(node, 'phase classification', 'phase evidence type');
                         const startDate = self.getNodeValue(node, 'production time span', 'from date');
+                        const artefactTypeConfidence = self.getNodeValue(node, 'phase classification', 'artefact type certainty')
                         const tileid = self.getTileId(node);
 
                         return {
@@ -189,6 +190,7 @@ function(_, ko, arches, reportUtils, ClassificationsTemplate) {
                             phaseEvidence,
                             productionTechnique,
                             startDate,
+                            artefactTypeConfidence,
                             tileid
                         };
                     }))

--- a/arches_her/pkg/graphs/resource_models/Artefact.json
+++ b/arches_her/pkg/graphs/resource_models/Artefact.json
@@ -19466,7 +19466,7 @@
                     "nodegroup_id": "99cfca45-381d-11e8-968a-dca90488358a",
                     "nodeid": "dffd2e88-4684-11ef-93c6-00155d72fe3c",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P141_assigned",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P42_assigned",
                     "sortorder": 0,
                     "sourcebranchpublication_id": null
                 },

--- a/arches_her/pkg/graphs/resource_models/Artefact.json
+++ b/arches_her/pkg/graphs/resource_models/Artefact.json
@@ -12142,11 +12142,11 @@
                 },
                 {
                     "description": null,
-                    "domainnode_id": "546b162d-3ba4-11eb-9ef2-f875a44e0e11",
+                    "domainnode_id": "546b1630-3ba4-11eb-9030-f875a44e0e11",
                     "edgeid": "f0506d8a-f91b-491a-a43c-839d66c9da95",
                     "graph_id": "343cc20c-2c5a-11e8-90fa-0242ac120005",
                     "name": null,
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P141_assigned",
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
                     "rangenode_id": "dffd2e88-4684-11ef-93c6-00155d72fe3c"
                 },
                 {
@@ -19466,7 +19466,7 @@
                     "nodegroup_id": "99cfca45-381d-11e8-968a-dca90488358a",
                     "nodeid": "dffd2e88-4684-11ef-93c6-00155d72fe3c",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P42_assigned",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
                     "sortorder": 0,
                     "sourcebranchpublication_id": null
                 },

--- a/arches_her/pkg/graphs/resource_models/Artefact.json
+++ b/arches_her/pkg/graphs/resource_models/Artefact.json
@@ -1451,6 +1451,61 @@
                     "widget_id": "10000000-0000-0000-0000-000000000004"
                 },
                 {
+                    "card_id": "99cfd3f5-381d-11e8-a6cf-dca90488358a",
+                    "config": {
+                        "defaultValue": "",
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "Artefact Type Certainty",
+                        "options": [
+                            {
+                                "children": [],
+                                "collector": "",
+                                "conceptid": "ef70b9c8-2317-46de-b8b3-73497d9d2fed",
+                                "id": "ab5445d1-514c-4ab5-9f92-c7d0c68c46f1",
+                                "sortorder": "",
+                                "text": "Certain"
+                            },
+                            {
+                                "children": [],
+                                "collector": "",
+                                "conceptid": "9333e08e-6407-434d-95b3-798c9cf5537c",
+                                "id": "a833c81c-c545-44c7-9a8d-f30caa20d0f7",
+                                "sortorder": "",
+                                "text": "Possible"
+                            },
+                            {
+                                "children": [],
+                                "collector": "",
+                                "conceptid": "179a8de4-4ad6-468c-97c4-4a62780cc98d",
+                                "id": "5098a178-ec32-4041-8999-a10d73cd826e",
+                                "sortorder": "",
+                                "text": "Probable"
+                            },
+                            {
+                                "children": [],
+                                "collector": "",
+                                "conceptid": "faea4c23-e89f-477a-b97c-50bc08f489c1",
+                                "id": "2d32062f-80b4-4293-94aa-46653ba5c632",
+                                "sortorder": "",
+                                "text": "Uncertain"
+                            }
+                        ],
+                        "placeholder": {
+                            "en": "Select an option"
+                        }
+                    },
+                    "id": "0f5f2d3b-b92d-4bc8-96ec-76b8c01d8cf0",
+                    "label": {
+                        "en": "Artefact Type Certainty"
+                    },
+                    "node_id": "dffd2e88-4684-11ef-93c6-00155d72fe3c",
+                    "sortorder": 2,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000009"
+                },
+                {
                     "card_id": "507099c0-381d-11e8-ac76-dca90488358a",
                     "config": {
                         "defaultValue": "d5366899-09ec-4db1-8a49-a32b7e4784e3",
@@ -1688,7 +1743,7 @@
                         "en": "Phase Certainty Metatype"
                     },
                     "node_id": "546b3d71-3ba4-11eb-b4a3-f875a44e0e11",
-                    "sortorder": 10,
+                    "sortorder": 12,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000002"
                 },
@@ -1717,7 +1772,7 @@
                         "en": "Phase Description"
                     },
                     "node_id": "546b3d72-3ba4-11eb-98ad-f875a44e0e11",
-                    "sortorder": 11,
+                    "sortorder": 13,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000005"
                 },
@@ -1739,7 +1794,7 @@
                         "en": "Phase Evidence Metatype"
                     },
                     "node_id": "546b3d73-3ba4-11eb-a73f-f875a44e0e11",
-                    "sortorder": 8,
+                    "sortorder": 10,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000002"
                 },
@@ -1761,7 +1816,7 @@
                         "en": "Phase Desctiption Metatype"
                     },
                     "node_id": "546b1631-3ba4-11eb-ba80-f875a44e0e11",
-                    "sortorder": 13,
+                    "sortorder": 15,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000002"
                 },
@@ -1839,7 +1894,7 @@
                         "en": "Phase Certainty"
                     },
                     "node_id": "546b1633-3ba4-11eb-a593-f875a44e0e11",
-                    "sortorder": 9,
+                    "sortorder": 11,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000009"
                 },
@@ -1861,7 +1916,7 @@
                         "en": "Phase Evidence Type"
                     },
                     "node_id": "546b1634-3ba4-11eb-b788-f875a44e0e11",
-                    "sortorder": 7,
+                    "sortorder": 9,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
                 },
@@ -1883,7 +1938,7 @@
                         "en": "Phase Description Type"
                     },
                     "node_id": "546b1635-3ba4-11eb-a503-f875a44e0e11",
-                    "sortorder": 12,
+                    "sortorder": 14,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000002"
                 },
@@ -1904,7 +1959,7 @@
                         "en": "Producer"
                     },
                     "node_id": "dde0f338-bd41-11ea-afd6-f875a44e0e11",
-                    "sortorder": 14,
+                    "sortorder": 16,
                     "visible": true,
                     "widget_id": "ff3c400a-76ec-11e7-a793-784f435179ea"
                 },
@@ -1926,7 +1981,7 @@
                         "en": "Material Metatype"
                     },
                     "node_id": "f283bce6-ab29-11ea-8729-f875a44e0e11",
-                    "sortorder": 20,
+                    "sortorder": 22,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000002"
                 },
@@ -2065,7 +2120,7 @@
                         "en": "Production Technique Metatype"
                     },
                     "node_id": "046750b8-8629-11ea-8a51-f875a44e0e11",
-                    "sortorder": 16,
+                    "sortorder": 18,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000002"
                 },
@@ -2087,7 +2142,7 @@
                         "en": "Production Method Metatype"
                     },
                     "node_id": "ce816430-8627-11ea-8f7c-f875a44e0e11",
-                    "sortorder": 18,
+                    "sortorder": 20,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000002"
                 },
@@ -3458,7 +3513,7 @@
                         "en": "Date Qualifier"
                     },
                     "node_id": "1d9500e3-0e04-11eb-af9a-f875a44e0e11",
-                    "sortorder": 5,
+                    "sortorder": 7,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000002"
                 },
@@ -3480,7 +3535,7 @@
                         "en": "Production Time Span Date Qualifier Metatype"
                     },
                     "node_id": "1d9500e6-0e04-11eb-b4f8-f875a44e0e11",
-                    "sortorder": 6,
+                    "sortorder": 8,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000002"
                 },
@@ -4245,7 +4300,7 @@
                         "en": "Production Date: To"
                     },
                     "node_id": "99cff7f8-381d-11e8-a059-dca90488358a",
-                    "sortorder": 4,
+                    "sortorder": 6,
                     "visible": true,
                     "widget_id": "adfd15ce-dbab-11e7-86d1-0fcf08612b27"
                 },
@@ -4637,7 +4692,7 @@
                         "en": "Period"
                     },
                     "node_id": "99cfffd1-381d-11e8-ab51-dca90488358a",
-                    "sortorder": 2,
+                    "sortorder": 4,
                     "visible": true,
                     "widget_id": "ff3c400a-76ec-11e7-a793-784f435179ea"
                 },
@@ -4662,7 +4717,7 @@
                         "en": "Production Date: From"
                     },
                     "node_id": "99cfe72e-381d-11e8-882c-dca90488358a",
-                    "sortorder": 3,
+                    "sortorder": 5,
                     "visible": true,
                     "widget_id": "adfd15ce-dbab-11e7-86d1-0fcf08612b27"
                 },
@@ -4733,7 +4788,7 @@
                         "en": "Production Method"
                     },
                     "node_id": "99cfe197-381d-11e8-8c16-dca90488358a",
-                    "sortorder": 17,
+                    "sortorder": 19,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000002"
                 },
@@ -4798,7 +4853,7 @@
                         "en": "Production Technique"
                     },
                     "node_id": "99cfdac2-381d-11e8-9521-dca90488358a",
-                    "sortorder": 15,
+                    "sortorder": 17,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000002"
                 },
@@ -6219,9 +6274,31 @@
                         "en": "Material"
                     },
                     "node_id": "6d3fdb54-1ffe-11ea-90f8-c4d9877d154e",
-                    "sortorder": 19,
+                    "sortorder": 21,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
+                },
+                {
+                    "card_id": "99cfd3f5-381d-11e8-a6cf-dca90488358a",
+                    "config": {
+                        "defaultValue": "f2054168-b8dc-416a-b6df-f5aff733c0c3",
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "Artefact Type Certainty Metatype",
+                        "options": [],
+                        "placeholder": {
+                            "en": "Select an option"
+                        }
+                    },
+                    "id": "c1257a76-c569-4a22-a198-5fac963e17bf",
+                    "label": {
+                        "en": "Artefact Type Certainty Metatype"
+                    },
+                    "node_id": "fd6930f2-4684-11ef-93c6-00155d72fe3c",
+                    "sortorder": 3,
+                    "visible": false,
+                    "widget_id": "10000000-0000-0000-0000-000000000002"
                 },
                 {
                     "card_id": "c30977af-991e-11ea-acde-f875a44e0e11",
@@ -12065,6 +12142,15 @@
                 },
                 {
                     "description": null,
+                    "domainnode_id": "546b162d-3ba4-11eb-9ef2-f875a44e0e11",
+                    "edgeid": "f0506d8a-f91b-491a-a43c-839d66c9da95",
+                    "graph_id": "343cc20c-2c5a-11e8-90fa-0242ac120005",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P141_assigned",
+                    "rangenode_id": "dffd2e88-4684-11ef-93c6-00155d72fe3c"
+                },
+                {
+                    "description": null,
                     "domainnode_id": "6d3fdb54-1ffe-11ea-90f8-c4d9877d154e",
                     "edgeid": "f283bce7-ab29-11ea-8627-f875a44e0e11",
                     "graph_id": "343cc20c-2c5a-11e8-90fa-0242ac120005",
@@ -13628,6 +13714,15 @@
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P7_took_place_at",
                     "rangenode_id": "f7cc62b1-f447-11eb-bde0-a87eeabdefba"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "dffd2e88-4684-11ef-93c6-00155d72fe3c",
+                    "edgeid": "f89dc465-8b1c-434f-aad5-6af830aa45a0",
+                    "graph_id": "343cc20c-2c5a-11e8-90fa-0242ac120005",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "fd6930f2-4684-11ef-93c6-00155d72fe3c"
                 }
             ],
             "functions_x_graphs": [
@@ -19353,6 +19448,29 @@
                     "sourcebranchpublication_id": null
                 },
                 {
+                    "alias": "artefact_type_certainty",
+                    "config": {
+                        "rdmCollection": "2b0f86cc-6d4a-483b-973e-9000c9d8b34d"
+                    },
+                    "datatype": "concept",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "343cc20c-2c5a-11e8-90fa-0242ac120005",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Artefact Type Certainty",
+                    "nodegroup_id": "99cfca45-381d-11e8-968a-dca90488358a",
+                    "nodeid": "dffd2e88-4684-11ef-93c6-00155d72fe3c",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P141_assigned",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
                     "alias": "date_of_assessment_end",
                     "config": {
                         "dateFormat": "YYYY-MM-DD"
@@ -23435,6 +23553,29 @@
                     "nodeid": "f7ccef78-f447-11eb-8948-a87eeabdefba",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E53_Place",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P89_falls_within",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "artefact_type_certainty_metatype",
+                    "config": {
+                        "rdmCollection": "1e63c514-eb9d-48d3-94b5-35e060e5f368"
+                    },
+                    "datatype": "concept",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "343cc20c-2c5a-11e8-90fa-0242ac120005",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Artefact Type Certainty Metatype",
+                    "nodegroup_id": "99cfca45-381d-11e8-968a-dca90488358a",
+                    "nodeid": "fd6930f2-4684-11ef-93c6-00155d72fe3c",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
                     "sortorder": 0,
                     "sourcebranchpublication_id": null
                 }

--- a/arches_her/templates/views/components/reports/scenes/classifications.htm
+++ b/arches_her/templates/views/components/reports/scenes/classifications.htm
@@ -41,6 +41,7 @@
                                 <th>{% trans "Start Date" %}</th>
                                 <th>{% trans "End Date" %}</th>
                                 <th>{% trans "Method" %}</th>
+                                <th class="none">{% trans "Artefact Type Confidence" %}</th>
                                 <th class="none">{% trans "Date Qualifier" %}</th>
                                 <th class="none">{% trans "Phase Evidence" %}</th>
                                 <th class="none">{% trans "Interpretation Confidence" %}</th>
@@ -58,6 +59,7 @@
                                 <td data-bind="text: startDate"></td>
                                 <td data-bind="text: endDate"></td>
                                 <td data-bind="text: method"></td>
+                                <td data-bind="text: artefactTypeConfidence"></td>
                                 <td data-bind="text: dateQualifier"></td>
                                 <td data-bind="text: phaseEvidence"></td>
                                 <td data-bind="text: interpretationConfidence"></td>


### PR DESCRIPTION
Addresses [#1273](https://github.com/archesproject/arches-her/issues/1273)

Adds Artefact Type Certainty and Artefact Type Certainty Metatype nodes on the same level as Artefact Type.
![image](https://github.com/user-attachments/assets/a2227f3e-b212-40de-a9fb-2ad3fadceb49)
![image](https://github.com/user-attachments/assets/fbea3829-b8ec-4664-a05c-d5b2716b46ce)

Resulting card looks as follows:
![image](https://github.com/user-attachments/assets/700af800-9633-4c3e-8604-d349133dfdfc)


@Philbox Need I'm sunsure whether Phase Classification is the correct parent nodegroup for Artefact Type Certainty, or if you think Artefact Type would be a better parent for it?
![image](https://github.com/user-attachments/assets/2c2158b7-3159-40f0-bede-096e0b92319a)
