### PR TITLE
Add Advice Start Date and End Date as columns to Consultation Advice table

### DIFF
--- a/arches_her/media/js/views/components/reports/consultation.js
+++ b/arches_her/media/js/views/components/reports/consultation.js
@@ -108,10 +108,10 @@ define([
             self.adviceTableConfig = {
                 ...self.defaultTableConfig,
                 "columns": [
-                    { "width": "40%" },
+                    { "width": "50%" },
                     { "width": "20%" },
-                    { "width": "15%" },
-                    { "width": "15%" },
+                    { "width": "10%" },
+                    { "width": "10%" },
                    null,
                 ]
             };

--- a/arches_her/media/js/views/components/reports/consultation.js
+++ b/arches_her/media/js/views/components/reports/consultation.js
@@ -108,8 +108,10 @@ define([
             self.adviceTableConfig = {
                 ...self.defaultTableConfig,
                 "columns": [
-                    { "width": "70%" },
+                    { "width": "40%" },
                     { "width": "20%" },
+                    { "width": "15%" },
+                    { "width": "15%" },
                    null,
                 ]
             };
@@ -225,8 +227,10 @@ define([
                 self.advice(adviceNode.map(node => {
                     const advice = self.getRawNodeValue(node, 'advice text', '@display_value');
                     const adviceType = self.getNodeValue(node, 'advice type');
+                    const adviceStartDate = self.getNodeValue(node, 'advice assignment', 'advice timespan', 'date advice applied', '@display_value');
+                    const adviceEndDate = self.getNodeValue(node, 'advice assignment', 'advice timespan', 'advice applied end date', '@display_value');
                     const tileid = self.getTileId(node);
-                    return {advice, adviceType, tileid};
+                    return {advice, adviceType, adviceStartDate, adviceEndDate, tileid};
                 }));
             };
 

--- a/arches_her/templates/views/components/reports/consultation.htm
+++ b/arches_her/templates/views/components/reports/consultation.htm
@@ -330,6 +330,8 @@
                                             <tr>
                                                 <th>{% trans "Advice" %}</th>
                                                 <th>{% trans "Advice Type" %}</th>
+                                                <th>{% trans "Advice Start Date" %}</th>
+                                                <th>{% trans "Advice End Date" %}</th>
                                                 <th class="aher-table-control all">{% trans "Actions" %}</th>
                                             </tr>
                                         </thead>
@@ -338,6 +340,8 @@
                                             <tr>
                                                 <td data-bind="html: advice"></td>
                                                 <td data-bind="text: adviceType"></td>
+                                                <td data-bind="text: adviceStartDate"></td>
+                                                <td data-bind="text: adviceEndDate"></td>
                                                 <td class="aher-table-control">
                                                     <div data-bind="if: $parent.cards.advice">
                                                         <a href="#" data-bind="onEnterkeyClick, onSpaceClick, click: function() {$parent.editTile(tileid, $parent.cards.advice)}">


### PR DESCRIPTION
Closes #1282

Adds columns for Advice start and end dates like so:
![image](https://github.com/user-attachments/assets/b1f77139-67a3-4cbd-a323-feb05089183a)

These columns allow the different Advice tiles to be sorted by either start or end date.