### PR TITLE
Remove height css as no longer required AB#70013

### DIFF
--- a/arches_her/media/css/project.css
+++ b/arches_her/media/css/project.css
@@ -11,8 +11,7 @@
     background: #ebeef0;
     overflow-y: auto;
     overflow-x: hidden;
-    min-height: 100vh;
-    }
+}
 
 /* End core styling overwrite for hotfixes*/
 


### PR DESCRIPTION
Original issue was here: https://github.com/archesproject/arches/issues/11124

Upon further investigation it was found to be an arches-her issue and not core. A height was set for a containing div and its no longer required. Removed the height CSS and the issue has been fixed.

Fixes #1246 

Was looking like this...

![image](https://github.com/user-attachments/assets/466b8491-297c-400d-b7ea-2c97f1080107)

...now looking like this...

![image](https://github.com/user-attachments/assets/e0ca6b9c-3119-4849-9c09-62b43e701e67)
