### PR TITLE
Fix for report tabs being read out using screen reader

### DIFF
--- a/arches_her/templates/views/components/reports/activity.htm
+++ b/arches_her/templates/views/components/reports/activity.htm
@@ -20,14 +20,17 @@
     <div class="aher-report-anchor-container">
         <ol class="aher-report-anchors breadcrumb">
             <!-- ko foreach: {data: sections, as: 'section'} -->
-            <li tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function(){$parent.activeSection(section.id)}, css: {active: $parent.activeSection() === section.id}, text: section.title" class="aher-report-a"></li>
+            <li tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function(){$parent.activeSection(section.id)},
+                css: {active: $parent.activeSection() === section.id},
+                text: section.title, attr: {'aria-controls': 'tabcontent_' + section.id, 'aria-expanded': $parent.activeSection() === section.id ? 'true' : 'false'}"
+                class="aher-report-a" aria-expanded="false"></li>
             <!-- /ko -->
         </ol>
     </div>
     <div class="aher-tabbed-report">
         <div class="aher-tabbed-report-content">
             <!-- Names Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'name'">
+            <div id="tabcontent_name" class="aher-report-page" data-bind="if: activeSection() === 'name'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/name',
                     params: {
@@ -38,7 +41,7 @@
                 }"></div>
             </div>
             <!-- Description Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'description'">
+            <div id="tabcontent_description" class="aher-report-page" data-bind="if: activeSection() === 'description'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/description',
                     params: {
@@ -49,7 +52,7 @@
                 }"></div>
             </div>
             <!-- Classification Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications'">
+            <div id="tabcontent_classifications" class="aher-report-page" data-bind="if: activeSection() === 'classifications'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/classifications',
                     params: {
@@ -60,7 +63,7 @@
                 }"></div>
             </div>
             <!-- Location Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'location'">
+            <div id="tabcontent_location" class="aher-report-page" data-bind="if: activeSection() === 'location'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/location',
                     params: {
@@ -70,7 +73,7 @@
                 }"></div>
             </div>
             <!-- Designation/Protection Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'protection'">
+            <div id="tabcontent_protection" class="aher-report-page" data-bind="if: activeSection() === 'protection'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/protection',
                     params: {
@@ -81,7 +84,7 @@
                 }"></div>
             </div>
             <!-- People Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'people'">
+            <div id="tabcontent_people" class="aher-report-page" data-bind="if: activeSection() === 'people'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/people',
                     params: {
@@ -90,7 +93,7 @@
                     }
                 }"></div>
             </div>
-            <div class="aher-report-page" data-bind="if: activeSection() === 'resources'">
+            <div id="tabcontent_resources" class="aher-report-page" data-bind="if: activeSection() === 'resources'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/resources',
                     params: {
@@ -100,7 +103,7 @@
                     }
                 }"></div>
             </div>
-            <div class="aher-report-page" data-bind="if: activeSection() === 'archive'">
+            <div id="tabcontent_archive" class="aher-report-page" data-bind="if: activeSection() === 'archive'" aria-live="polite">
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title"><i tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.activityArchive)}, css: {'fa-angle-double-right': visible.activityArchive(), 'fa-angle-double-up': !visible.activityArchive()}"  class="fa toggle"></i> {% trans "Activity Archive Material" %}</h2>
                     <!-- ko if: checkCardsAvailable($data.cards) -->
@@ -154,7 +157,7 @@
                 </div>
             </div>
              <!-- JSON Tab -->
-            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'">
+            <div id="tabcontent_json" class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'" aria-live="polite">
                 <div class="aher-flex-col" data-bind="component: {
                     name: 'views/components/reports/scenes/json',
                     params: {

--- a/arches_her/templates/views/components/reports/application-area.htm
+++ b/arches_her/templates/views/components/reports/application-area.htm
@@ -20,14 +20,17 @@
     <div class="aher-report-anchor-container">
         <ol class="aher-report-anchors breadcrumb">
             <!-- ko foreach: {data: sections, as: 'section'} -->
-            <li tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function(){$parent.activeSection(section.id)}, css: {active: $parent.activeSection() === section.id}, text: section.title" class="aher-report-a"></li>
+            <li tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function(){$parent.activeSection(section.id)},
+                css: {active: $parent.activeSection() === section.id},
+                text: section.title, attr: {'aria-controls': 'tabcontent_' + section.id, 'aria-expanded': $parent.activeSection() === section.id ? 'true' : 'false'}"
+                class="aher-report-a" aria-expanded="false"></li>
             <!-- /ko -->
         </ol>
     </div>
     <div class="aher-tabbed-report">
         <div class="aher-tabbed-report-content">
             <!-- Names Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'name'">
+            <div id="tabcontent_name" class="aher-report-page" data-bind="if: activeSection() === 'name'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/name',
                     params: {
@@ -38,7 +41,7 @@
                 }"></div>
             </div>
             <!-- Description Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'description'">
+            <div id="tabcontent_description" class="aher-report-page" data-bind="if: activeSection() === 'description'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/description',
                     params: {
@@ -48,7 +51,7 @@
                 }"></div>
             </div>
             <!-- Location Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'location'">
+            <div id="tabcontent_location" class="aher-report-page" data-bind="if: activeSection() === 'location'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/location',
                     params: {
@@ -59,7 +62,7 @@
                 }"></div>
             </div>
             <!-- Designation/Protection Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'protection'">
+            <div id="tabcontent_protection" class="aher-report-page" data-bind="if: activeSection() === 'protection'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/protection',
                     params: {
@@ -70,7 +73,7 @@
                 }"></div>
             </div>
             <!-- Resources Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'resources'">
+            <div id="tabcontent_resources" class="aher-report-page" data-bind="if: activeSection() === 'resources'" aria-live="polite">
 
                 <!-- Referenced By section -->
                 <div data-bind="component: {
@@ -139,7 +142,7 @@
                 </div>
             </div>
             <!-- Classification Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications'">
+            <div id="tabcontent_classifications" class="aher-report-page" data-bind="if: activeSection() === 'classifications'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/classifications',
                     params: {
@@ -150,7 +153,7 @@
                 }"></div>
             </div>
              <!-- JSON Tab -->
-            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'">
+            <div id="tabcontent_json" class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'" aria-live="polite">
                 <div class="aher-flex-col" data-bind="component: {
                     name: 'views/components/reports/scenes/json',
                     params: {
@@ -159,7 +162,7 @@
                 }"></div>
             </div>
             <!-- Communication Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'communication'">
+            <div id="tabcontent_communication" class="aher-report-page" data-bind="if: activeSection() === 'communication'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/communication',
                     params: {

--- a/arches_her/templates/views/components/reports/area.htm
+++ b/arches_her/templates/views/components/reports/area.htm
@@ -20,14 +20,17 @@
     <div class="aher-report-anchor-container">
         <ol class="aher-report-anchors breadcrumb">
             <!-- ko foreach: {data: sections, as: 'section'} -->
-            <li tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function(){$parent.activeSection(section.id)}, css: {active: $parent.activeSection() === section.id}, text: section.title" class="aher-report-a"></li>
+            <li tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function(){$parent.activeSection(section.id)},
+                css: {active: $parent.activeSection() === section.id},
+                text: section.title, attr: {'aria-controls': 'tabcontent_' + section.id, 'aria-expanded': $parent.activeSection() === section.id ? 'true' : 'false'}"
+                class="aher-report-a" aria-expanded="false"></li>
             <!-- /ko -->
         </ol>
     </div>
     <div class="aher-tabbed-report">
         <div class="aher-tabbed-report-content">
             <!-- Names Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'name'">
+            <div id="tabcontent_name" class="aher-report-page" data-bind="if: activeSection() === 'name'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/name',
                     params: {
@@ -38,7 +41,7 @@
                 }"></div>
             </div>
             <!-- Description Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'description'">
+            <div id="tabcontent_description" class="aher-report-page" data-bind="if: activeSection() === 'description'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/description',
                     params: {
@@ -49,7 +52,7 @@
                 }"></div>
             </div>
             <!-- Classification Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications'">
+            <div id="tabcontent_classifications" class="aher-report-page" data-bind="if: activeSection() === 'classifications'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/classifications',
                     params: {
@@ -60,7 +63,7 @@
                 }"></div>
             </div>
             <!-- Location Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'location'">
+            <div id="tabcontent_location" class="aher-report-page" data-bind="if: activeSection() === 'location'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/location',
                     params: {
@@ -71,7 +74,7 @@
                 }"></div>
             </div>
             <!-- Designation/Protection Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'protection'">
+            <div id="tabcontent_protection" class="aher-report-page" data-bind="if: activeSection() === 'protection'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/protection',
                     params: {
@@ -81,7 +84,7 @@
                 }"></div>
             </div>
             <!-- Assessments Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'assessments'">
+            <div id="tabcontent_assessments" class="aher-report-page" data-bind="if: activeSection() === 'assessments'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/assessments',
                     params: {
@@ -91,7 +94,7 @@
                 }"></div>
             </div>
             <!-- Images Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'images'">
+            <div id="tabcontent_images" class="aher-report-page" data-bind="if: activeSection() === 'images'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/images',
                     params: {
@@ -101,7 +104,7 @@
                 }"></div>
             </div>
             <!-- People Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'people'">
+            <div id="tabcontent_people" class="aher-report-page" data-bind="if: activeSection() === 'people'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/people',
                     params: {
@@ -111,7 +114,7 @@
                 }"></div>
             </div>
             <!-- Resources Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'resources'">
+            <div id="tabcontent_resources" class="aher-report-page" data-bind="if: activeSection() === 'resources'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/resources',
                     params: {
@@ -122,7 +125,7 @@
                 }"></div>
             </div>
              <!-- JSON Tab -->
-            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'">
+            <div id="tabcontent_json" class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'" aria-live="polite">
                 <div class="aher-flex-col" data-bind="component: {
                     name: 'views/components/reports/scenes/json',
                     params: {

--- a/arches_her/templates/views/components/reports/artefact.htm
+++ b/arches_her/templates/views/components/reports/artefact.htm
@@ -20,14 +20,17 @@
     <div class="aher-report-anchor-container">
         <ol class="aher-report-anchors breadcrumb">
             <!-- ko foreach: {data: sections, as: 'section'} -->
-            <li tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function(){$parent.activeSection(section.id)}, css: {active: $parent.activeSection() === section.id}, text: section.title" class="aher-report-a"></li>
+            <li tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function(){$parent.activeSection(section.id)},
+                css: {active: $parent.activeSection() === section.id},
+                text: section.title, attr: {'aria-controls': 'tabcontent_' + section.id, 'aria-expanded': $parent.activeSection() === section.id ? 'true' : 'false'}"
+                class="aher-report-a" aria-expanded="false"></li>
             <!-- /ko -->
         </ol>
     </div>
     <div class="aher-tabbed-report">
         <div class="aher-tabbed-report-content">
             <!-- Names Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'name'">
+            <div id="tabcontent_name" class="aher-report-page" data-bind="if: activeSection() === 'name'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/name',
                     params: {
@@ -38,7 +41,7 @@
                 }"></div>
             </div>
             <!-- Description Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'description'">
+            <div id="tabcontent_description" class="aher-report-page" data-bind="if: activeSection() === 'description'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/description',
                     params: {
@@ -49,7 +52,7 @@
                 }"></div>
             </div>
             <!-- Classification Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications'">
+            <div id="tabcontent_classifications" class="aher-report-page" data-bind="if: activeSection() === 'classifications'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/classifications',
                     params: {
@@ -60,7 +63,7 @@
                 }"></div>
             </div>
             <!-- Location Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'location'">
+            <div id="tabcontent_location" class="aher-report-page" data-bind="if: activeSection() === 'location'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/location',
                     params: {
@@ -71,7 +74,7 @@
                 }"></div>
             </div>
             <!-- Publication Details Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'publication'">
+            <div id="tabcontent_publication" class="aher-report-page" data-bind="if: activeSection() === 'publication'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/copyright',
                     params: {
@@ -81,7 +84,7 @@
                 }"></div>
             </div>
             <!-- Discovery Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'discovery'">
+            <div id="tabcontent_discovery" class="aher-report-page" data-bind="if: activeSection() === 'discovery'" aria-live="polite">
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title"><i tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.discovery)}, css: {'fa-angle-double-right': visible.discovery(), 'fa-angle-double-up': !visible.discovery()}" class="fa toggle"></i> {% trans "Discovery" %}</h2>
                     <a class="aher-report-a" data-bind="{if: cards.discovery, event:{ mousedown:function(d, e){addNewTile(cards.discovery, e)}}}"><i class="fa fa-mail-reply"></i> <span data-bind="if: discovery().length">{% trans "Edit Discovery" %}</span><span data-bind="ifnot: discovery().length">{% trans "Add Discovery" %}</span></a>
@@ -184,7 +187,7 @@
                 </div>
             </div>
             <!-- Designation/Protection Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'protection'">
+            <div id="tabcontent_protection" class="aher-report-page" data-bind="if: activeSection() === 'protection'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/protection',
                     params: {
@@ -195,7 +198,7 @@
                 }"></div>
             </div>
             <!-- Assessments Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'assessments'">
+            <div id="tabcontent_assessments" class="aher-report-page" data-bind="if: activeSection() === 'assessments'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/assessments',
                     params: {
@@ -206,7 +209,7 @@
                 }"></div>
             </div>
             <!-- Archive Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'archive'">
+            <div id="tabcontent_archive" class="aher-report-page" data-bind="if: activeSection() === 'archive'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/archive',
                     params: {
@@ -217,7 +220,7 @@
                 }"></div>
             </div>
             <!-- Resources Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'resources'">
+            <div id="tabcontent_resources" class="aher-report-page" data-bind="if: activeSection() === 'resources'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/resources',
                     params: {
@@ -228,7 +231,7 @@
                 }"></div>
             </div>
              <!-- JSON Tab -->
-            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'">
+            <div id="tabcontent_json" class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'" aria-live="polite">
                 <div class="aher-flex-col" data-bind="component: {
                     name: 'views/components/reports/scenes/json',
                     params: {

--- a/arches_her/templates/views/components/reports/bibliographic-source.htm
+++ b/arches_her/templates/views/components/reports/bibliographic-source.htm
@@ -20,14 +20,17 @@
     <div class="aher-report-anchor-container">
         <ol class="aher-report-anchors breadcrumb">
             <!-- ko foreach: {data: sections, as: 'section'} -->
-            <li tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function(){$parent.activeSection(section.id)}, css: {active: $parent.activeSection() === section.id}, text: section.title" class="aher-report-a"></li>
+            <li tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function(){$parent.activeSection(section.id)},
+                css: {active: $parent.activeSection() === section.id},
+                text: section.title, attr: {'aria-controls': 'tabcontent_' + section.id, 'aria-expanded': $parent.activeSection() === section.id ? 'true' : 'false'}"
+                class="aher-report-a" aria-expanded="false"></li>
             <!-- /ko -->
         </ol>
     </div>
     <div class="aher-tabbed-report">
         <div class="aher-tabbed-report-content">
             <!-- Names Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'name'">
+            <div id="tabcontent_name" class="aher-report-page" data-bind="if: activeSection() === 'name'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/name',
                     params: {
@@ -38,7 +41,7 @@
                     }
                 }"></div>
             </div>
-            <div class="aher-report-page" data-bind="if: activeSection() === 'source'">
+            <div id="tabcontent_source" class="aher-report-page" data-bind="if: activeSection() === 'source'" aria-live="polite">
 
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title"><i tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.sourceNames)}, css: {'fa-angle-double-right': visible.sourceNames(), 'fa-angle-double-up': !visible.sourceNames()}" class="fa toggle"></i> {% trans "Names" %}</h2>
@@ -101,7 +104,7 @@
                 </div>
             </div>
             <!-- Description Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'description'">
+            <div id="tabcontent_description" class="aher-report-page" data-bind="if: activeSection() === 'description'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/description',
                     params: {
@@ -111,7 +114,7 @@
                 }"></div>
             </div>
             <!-- Classification Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications'">
+            <div id="tabcontent_classifications" class="aher-report-page" data-bind="if: activeSection() === 'classifications'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/classifications',
                     params: {
@@ -122,7 +125,7 @@
                 }"></div>
             </div>
             <!-- Publication Details Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'publication'">
+            <div id="tabcontent_publication" class="aher-report-page" data-bind="if: activeSection() === 'publication'" aria-live="polite">
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title"><i tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.publication)}, css: {'fa-angle-double-right': visible.publication(), 'fa-angle-double-up': !visible.publication()}" class="fa toggle"></i> {% trans "Publication" %}</h2>
                     <span data-bind="if: cards.publication && (!publication().length || cards.publication.cardinality == 'n')">
@@ -234,7 +237,7 @@
                 }"></div>
             </div>
            <!-- Resources Tab -->
-           <div class="aher-report-page" data-bind="if: activeSection() === 'resources'">
+           <div id="tabcontent_resources" class="aher-report-page" data-bind="if: activeSection() === 'resources'" aria-live="polite">
                <div data-bind="component: {
                    name: 'views/components/reports/scenes/resources',
                    params: {
@@ -245,7 +248,7 @@
                }"></div>
            </div>
              <!-- JSON Tab -->
-            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'">
+            <div id="tabcontent_json" class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'" aria-live="polite">
                 <div class="aher-flex-col" data-bind="component: {
                     name: 'views/components/reports/scenes/json',
                     params: {

--- a/arches_her/templates/views/components/reports/consultation.htm
+++ b/arches_her/templates/views/components/reports/consultation.htm
@@ -20,14 +20,17 @@
     <div class="aher-report-anchor-container">
         <ol class="aher-report-anchors breadcrumb">
             <!-- ko foreach: {data: sections, as: 'section'} -->
-            <li tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function(){$parent.activeSection(section.id)}, css: {active: $parent.activeSection() === section.id}, text: section.title" class="aher-report-a"></li>
+            <li tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function(){$parent.activeSection(section.id)},
+                css: {active: $parent.activeSection() === section.id},
+                text: section.title, attr: {'aria-controls': 'tabcontent_' + section.id, 'aria-expanded': $parent.activeSection() === section.id ? 'true' : 'false'}"
+                class="aher-report-a" aria-expanded="false"></li>
             <!-- /ko -->
         </ol>
     </div>
     <div class="aher-tabbed-report">
         <div class="aher-tabbed-report-content">
             <!-- Consultation Details Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'details'">
+            <div id="tabcontent_details" class="aher-report-page" data-bind="if: activeSection() === 'details'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/name',
                     params: {
@@ -59,7 +62,7 @@
                 }"></div>
             </div>
             <!-- Location Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'location'">
+            <div id="tabcontent_location" class="aher-report-page" data-bind="if: activeSection() === 'location'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/default',
                     params: {
@@ -76,7 +79,7 @@
                 }"></div>
             </div>
             <!-- Planning Reference Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'references'">
+            <div id="tabcontent_references" class="aher-report-page" data-bind="if: activeSection() === 'references'" aria-live="polite">
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title"><i tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.references)}, css: {'fa-angle-double-right': visible.references(), 'fa-angle-double-up': !visible.references()}"  class="fa toggle"></i> {% trans "External Cross References" %}</h2>
                     <a data-bind="{if: cards['external cross references'], click: function(){addNewTile(cards['external cross references'])}}" class="aher-report-a"><i class="fa fa-mail-reply"></i> {% trans "Add external cross references" %}</a>
@@ -179,7 +182,7 @@
                 </div>
             </div>
             <!-- Contacts Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'contacts'">
+            <div id="tabcontent_contacts" class="aher-report-page" data-bind="if: activeSection() === 'contacts'" aria-live="polite">
                 <h2 class="aher-report-section-title"><i tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.contacts)}, css: {'fa-angle-double-right': visible.contacts(), 'fa-angle-double-up': !visible.contacts()}" class="fa toggle"></i> {% trans "Contacts" %}</h2>
                 <a href="#" data-bind="{if: cards.contacts, click: function(){ addNewTile(cards.contacts) }}" class="aher-report-a">
 
@@ -261,7 +264,7 @@
             </div>
 
             <!-- Consultation Progression Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'progression'">
+            <div id="tabcontent_progression" class="aher-report-page" data-bind="if: activeSection() === 'progression'" aria-live="polite">
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title"><i tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.proposal)}, css: {'fa-angle-double-right': visible.proposal(), 'fa-angle-double-up': !visible.proposal()}"  class="fa toggle"></i> {% trans "Proposal" %}</h2>
                     <a href="#" data-bind="{if: cards.proposal, click: function(){addNewTile(cards.proposal)}}" class="aher-report-a"><i class="fa fa-mail-reply"></i> {% trans "Add proposal" %}</a>
@@ -489,7 +492,7 @@
                 </div>
             </div>
             <!-- Correspondence Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'correspondence'">
+            <div id="tabcontent_correspondence" class="aher-report-page" data-bind="if: activeSection() === 'correspondence'" aria-live="polite">
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title"><i tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.correspondence)}, css: {'fa-angle-double-right': visible.correspondence(), 'fa-angle-double-up': !visible.correspondence()}"  class="fa toggle"></i> {% trans "Correspondence" %}</h2>
                     <a href="#" data-bind="{if: cards.correspondence, click: function(){addNewTile(cards.correspondence)}}" class="aher-report-a"><i class="fa fa-mail-reply"></i> {% trans "Add Correspondence" %}</a>
@@ -598,7 +601,7 @@
                 </div>
             </div>
             <!-- Site Visit Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'sitevisits'">
+            <div id="tabcontent_sitevisits" class="aher-report-page" data-bind="if: activeSection() === 'sitevisits'" aria-live="polite">
                 <h2 class="aher-report-section-title"><i tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.siteVisits)}, css: {'fa-angle-double-right': visible.siteVisits(), 'fa-angle-double-up': !visible.siteVisits()}" class="fa toggle"></i> {% trans "Site Visits" %}</h2>
                 <a data-bind="{if: cards['site visits'], click: function(){ addNewTile(cards['site visits']) }}" class="aher-report-a">
                     <i class="fa fa-mail-reply"></i>
@@ -792,7 +795,7 @@
                 </div>
             </div>
             <!-- Resources Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'resources'">
+            <div id="tabcontent_resources" class="aher-report-page" data-bind="if: activeSection() === 'resources'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/resources',
                     params: {
@@ -803,7 +806,7 @@
                 }"></div>
             </div>
              <!-- JSON Tab -->
-            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'">
+            <div id="tabcontent_json" class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'" aria-live="polite">
                 <div class="aher-flex-col" data-bind="component: {
                     name: 'views/components/reports/scenes/json',
                     params: {

--- a/arches_her/templates/views/components/reports/digital-object.htm
+++ b/arches_her/templates/views/components/reports/digital-object.htm
@@ -20,14 +20,17 @@
     <div class="aher-report-anchor-container">
         <ol class="aher-report-anchors breadcrumb">
             <!-- ko foreach: {data: sections, as: 'section'} -->
-            <li tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function(){$parent.activeSection(section.id)}, css: {active: $parent.activeSection() === section.id}, text: section.title" class="aher-report-a"></li>
+            <li tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function(){$parent.activeSection(section.id)},
+                css: {active: $parent.activeSection() === section.id},
+                text: section.title, attr: {'aria-controls': 'tabcontent_' + section.id, 'aria-expanded': $parent.activeSection() === section.id ? 'true' : 'false'}"
+                class="aher-report-a" aria-expanded="false"></li>
             <!-- /ko -->
         </ol>
     </div>
     <div class="aher-tabbed-report">
         <div class="aher-tabbed-report-content">
             <!-- Names Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'name'">
+            <div id="tabcontent_name" class="aher-report-page" data-bind="if: activeSection() === 'name'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/name',
                     params: {
@@ -38,7 +41,7 @@
                 }"></div>
             </div>
             <!-- Description Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'description'">
+            <div id="tabcontent_description" class="aher-report-page" data-bind="if: activeSection() === 'description'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/description',
                     params: {
@@ -48,7 +51,7 @@
                 }"></div>
             </div>
             <!-- Publication Details Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'publication'">
+            <div id="tabcontent_publication" class="aher-report-page" data-bind="if: activeSection() === 'publication'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/copyright',
                     params: {
@@ -58,7 +61,7 @@
                 }"></div>
             </div>
             <!-- File Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'file'">
+            <div id="tabcontent_file" class="aher-report-page" data-bind="if: activeSection() === 'file'" aria-live="polite">
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title"><i tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.files)}, css: {'fa-angle-double-right': visible.files(), 'fa-angle-double-up': !visible.files()}"  class="fa toggle"></i> {% trans "Files" %}</h2>
                     <a data-bind="{if: cards['file'], click: function(){addNewTile(cards['file'])}}" class="aher-report-a">
@@ -104,7 +107,7 @@
                 }"></div>
             </div>
              <!-- JSON Tab -->
-            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'">
+            <div id="tabcontent_json" class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'" aria-live="polite">
                 <div class="aher-flex-col" data-bind="component: {
                     name: 'views/components/reports/scenes/json',
                     params: {

--- a/arches_her/templates/views/components/reports/heritage-story.htm
+++ b/arches_her/templates/views/components/reports/heritage-story.htm
@@ -20,14 +20,17 @@
     <div class="aher-report-anchor-container">
         <ol class="aher-report-anchors breadcrumb">
             <!-- ko foreach: {data: sections, as: 'section'} -->
-            <li tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function(){$parent.activeSection(section.id)}, css: {active: $parent.activeSection() === section.id}, text: section.title" class="aher-report-a"></li>
+            <li tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function(){$parent.activeSection(section.id)},
+                css: {active: $parent.activeSection() === section.id},
+                text: section.title, attr: {'aria-controls': 'tabcontent_' + section.id, 'aria-expanded': $parent.activeSection() === section.id ? 'true' : 'false'}"
+                class="aher-report-a" aria-expanded="false"></li>
             <!-- /ko -->
         </ol>
     </div>
     <div class="aher-tabbed-report">
         <div class="aher-tabbed-report-content">
             <!-- Names Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'name'">
+            <div id="tabcontent_name" class="aher-report-page" data-bind="if: activeSection() === 'name'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/name',
                     params: {
@@ -38,7 +41,7 @@
                 }"></div>
             </div>
             <!-- Description Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'description'">
+            <div id="tabcontent_description" class="aher-report-page" data-bind="if: activeSection() === 'description'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/description',
                     params: {
@@ -49,7 +52,7 @@
                 }"></div>
             </div>
             <!-- Location Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'location'">
+            <div id="tabcontent_location" class="aher-report-page" data-bind="if: activeSection() === 'location'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/location',
                     params: {
@@ -60,7 +63,7 @@
                 }"></div>
             </div>
             <!-- Resources Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'resources'">
+            <div id="tabcontent_resources" class="aher-report-page" data-bind="if: activeSection() === 'resources'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/resources',
                     params: {
@@ -71,7 +74,7 @@
                 }"></div>
             </div>
              <!-- JSON Tab -->
-            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'">
+            <div id="tabcontent_json" class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'" aria-live="polite">
                 <div class="aher-flex-col" data-bind="component: {
                     name: 'views/components/reports/scenes/json',
                     params: {

--- a/arches_her/templates/views/components/reports/historic-aircraft.htm
+++ b/arches_her/templates/views/components/reports/historic-aircraft.htm
@@ -20,14 +20,17 @@
     <div class="aher-report-anchor-container">
         <ol class="aher-report-anchors breadcrumb">
             <!-- ko foreach: {data: sections, as: 'section'} -->
-            <li tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function(){$parent.activeSection(section.id)}, css: {active: $parent.activeSection() === section.id}, text: section.title" class="aher-report-a"></li>
+            <li tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function(){$parent.activeSection(section.id)},
+                css: {active: $parent.activeSection() === section.id},
+                text: section.title, attr: {'aria-controls': 'tabcontent_' + section.id, 'aria-expanded': $parent.activeSection() === section.id ? 'true' : 'false'}"
+                class="aher-report-a" aria-expanded="false"></li>
             <!-- /ko -->
         </ol>
     </div>
     <div class="aher-tabbed-report">
         <div class="aher-tabbed-report-content">
             <!-- Names Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'name'">
+            <div id="tabcontent_name" class="aher-report-page" data-bind="if: activeSection() === 'name'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/name',
                     params: {
@@ -37,7 +40,7 @@
                 }"></div>
             </div>
             <!-- Description Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'description'">
+            <div id="tabcontent_description" class="aher-report-page" data-bind="if: activeSection() === 'description'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/description',
                     params: {
@@ -48,7 +51,7 @@
                 }"></div>
             </div>
             <!-- Classification Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications'">
+            <div id="tabcontent_classifications" class="aher-report-page" data-bind="if: activeSection() === 'classifications'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/classifications',
                     params: {
@@ -59,7 +62,7 @@
                 }"></div>
             </div>
             <!-- Location Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'location'">
+            <div id="tabcontent_location" class="aher-report-page" data-bind="if: activeSection() === 'location'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/location',
                     params: {
@@ -69,7 +72,7 @@
                 }"></div>
             </div>
             <!-- Designation/Protection Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'protection'">
+            <div id="tabcontent_protection" class="aher-report-page" data-bind="if: activeSection() === 'protection'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/protection',
                     params: {
@@ -79,7 +82,7 @@
                 }"></div>
             </div>
             <!-- Assessments Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'assessments'">
+            <div id="tabcontent_assessments" class="aher-report-page" data-bind="if: activeSection() === 'assessments'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/assessments',
                     params: {
@@ -89,7 +92,7 @@
                 }"></div>
             </div>
             <!-- Status/Owner Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'status'">
+            <div id="tabcontent_status" class="aher-report-page" data-bind="if: activeSection() === 'status'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/default',
                     params: {
@@ -98,7 +101,7 @@
                 }"></div>
             </div>
             <!-- Journeys -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'journey'">
+            <div id="tabcontent_journey" class="aher-report-page" data-bind="if: activeSection() === 'journey'" aria-live="polite">
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title"><i tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.flights)}, css: {'fa-angle-double-right': visible.flights(), 'fa-angle-double-up': !visible.flights()}" class="fa toggle"></i> {% trans "Flights" %}</h2>
                     <a class="aher-report-a" data-bind="{if: cards.flights, event:{ mousedown:function(d, e){addNewTile(cards.flights, e)}}}"><i class="fa fa-mail-reply"></i> <span data-bind="if: flights().length">{% trans "Edit Flight" %}</span><span data-bind="ifnot: flights().length">{% trans "Add Flight" %}</span></a>
@@ -258,7 +261,7 @@
                 </div>
             </div>
             <!-- People Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'people'">
+            <div id="tabcontent_people" class="aher-report-page" data-bind="if: activeSection() === 'people'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/people',
                     params: {
@@ -268,7 +271,7 @@
                 }"></div>
             </div>
             <!-- Resources Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'resources'">
+            <div id="tabcontent_resources" class="aher-report-page" data-bind="if: activeSection() === 'resources'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/resources',
                     params: {
@@ -279,7 +282,7 @@
                 }"></div>
             </div>
              <!-- JSON Tab -->
-            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'">
+            <div id="tabcontent_json" class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'" aria-live="polite">
                 <div class="aher-flex-col" data-bind="component: {
                     name: 'views/components/reports/scenes/json',
                     params: {

--- a/arches_her/templates/views/components/reports/historic-landscape-characterization.htm
+++ b/arches_her/templates/views/components/reports/historic-landscape-characterization.htm
@@ -20,14 +20,17 @@
     <div class="aher-report-anchor-container">
         <ol class="aher-report-anchors breadcrumb">
             <!-- ko foreach: {data: sections, as: 'section'} -->
-            <li tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function(){$parent.activeSection(section.id)}, css: {active: $parent.activeSection() === section.id}, text: section.title" class="aher-report-a"></li>
+            <li tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function(){$parent.activeSection(section.id)},
+                css: {active: $parent.activeSection() === section.id},
+                text: section.title, attr: {'aria-controls': 'tabcontent_' + section.id, 'aria-expanded': $parent.activeSection() === section.id ? 'true' : 'false'}"
+                class="aher-report-a" aria-expanded="false"></li>
             <!-- /ko -->
         </ol>
     </div>
     <div class="aher-tabbed-report">
         <div class="aher-tabbed-report-content">
             <!-- Names Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'name'">
+            <div id="tabcontent_name" class="aher-report-page" data-bind="if: activeSection() === 'name'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/name',
                     params: {
@@ -38,7 +41,7 @@
                 }"></div>
             </div>
             <!-- Description Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'description'">
+            <div id="tabcontent_description" class="aher-report-page" data-bind="if: activeSection() === 'description'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/description',
                     params: {
@@ -49,7 +52,7 @@
                 }"></div>
             </div>
             <!-- Location Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'location'">
+            <div id="tabcontent_location" class="aher-report-page" data-bind="if: activeSection() === 'location'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/location',
                     params: {
@@ -60,7 +63,7 @@
                 }"></div>
             </div>
             <!-- Resources Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'resources'">
+            <div id="tabcontent_resources" class="aher-report-page" data-bind="if: activeSection() === 'resources'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/resources',
                     params: {
@@ -70,7 +73,7 @@
                     }
                 }"></div>
             </div>
-            <div class="aher-report-page" data-bind="if: activeSection() === 'hlc-attributes'">
+            <div id="tabcontent_hlc-attributes" class="aher-report-page" data-bind="if: activeSection() === 'hlc-attributes'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/default',
                     params: {
@@ -79,7 +82,7 @@
                 }"></div>
             </div>
             <!-- Classification Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications'">
+            <div id="tabcontent_classifications" class="aher-report-page" data-bind="if: activeSection() === 'classifications'" aria-live="polite">
                 <!-- HLC Phase section -->
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title"><i tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.historicLandscapeClassificationPhase)}, css: {'fa-angle-double-right': visible.historicLandscapeClassificationPhase(), 'fa-angle-double-up': !visible.historicLandscapeClassificationPhase()}" class="fa toggle"></i> {% trans "HLC Phase" %}</h2>
@@ -163,7 +166,7 @@
                 </div>
             </div>
              <!-- JSON Tab -->
-            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'">
+            <div id="tabcontent_json" class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'" aria-live="polite">
                 <div class="aher-flex-col" data-bind="component: {
                     name: 'views/components/reports/scenes/json',
                     params: {
@@ -172,7 +175,7 @@
                 }"></div>
             </div>
             <!-- Communication Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'communication'">
+            <div id="tabcontent_communication" class="aher-report-page" data-bind="if: activeSection() === 'communication'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/communication',
                     params: {

--- a/arches_her/templates/views/components/reports/maritime-vessel.htm
+++ b/arches_her/templates/views/components/reports/maritime-vessel.htm
@@ -20,14 +20,17 @@
     <div class="aher-report-anchor-container">
         <ol class="aher-report-anchors breadcrumb">
             <!-- ko foreach: {data: sections, as: 'section'} -->
-            <li tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function(){$parent.activeSection(section.id)}, css: {active: $parent.activeSection() === section.id}, text: section.title" class="aher-report-a"></li>
+            <li tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function(){$parent.activeSection(section.id)},
+                css: {active: $parent.activeSection() === section.id},
+                text: section.title, attr: {'aria-controls': 'tabcontent_' + section.id, 'aria-expanded': $parent.activeSection() === section.id ? 'true' : 'false'}"
+                class="aher-report-a" aria-expanded="false"></li>
             <!-- /ko -->
         </ol>
     </div>
     <div class="aher-tabbed-report">
         <div class="aher-tabbed-report-content">
             <!-- Names Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'name'">
+            <div id="tabcontent_name" class="aher-report-page" data-bind="if: activeSection() === 'name'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/name',
                     params: {
@@ -37,7 +40,7 @@
                 }"></div>
             </div>
             <!-- Description Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'description'">
+            <div id="tabcontent_description" class="aher-report-page" data-bind="if: activeSection() === 'description'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/description',
                     params: {
@@ -48,7 +51,7 @@
                 }"></div>
             </div>
             <!-- Classification Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications'">
+            <div id="tabcontent_classifications" class="aher-report-page" data-bind="if: activeSection() === 'classifications'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/classifications',
                     params: {
@@ -59,7 +62,7 @@
                 }"></div>
             </div>
             <!-- Location Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'location'">
+            <div id="tabcontent_location" class="aher-report-page" data-bind="if: activeSection() === 'location'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/location',
                     params: {
@@ -69,7 +72,7 @@
                 }"></div>
             </div>
             <!-- Status/Owner Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'status'">
+            <div id="tabcontent_status" class="aher-report-page" data-bind="if: activeSection() === 'status'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/default',
                     params: {
@@ -183,7 +186,7 @@
             </div>
 
             <!-- Journeys -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'journey'">
+            <div id="tabcontent_journey" class="aher-report-page" data-bind="if: activeSection() === 'journey'" aria-live="polite">
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title"><i tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.voyages)}, css: {'fa-angle-double-right': visible.voyages(), 'fa-angle-double-up': !visible.voyages()}" class="fa toggle"></i> {% trans "Voyages" %}</h2>
                     <a class="aher-report-a" data-bind="{if: cards.voyages, event:{ mousedown:function(d, e){addNewTile(cards.voyages, e)}}}"><i class="fa fa-mail-reply"></i> <span>{% trans "Add Voyage" %}</span></a>
@@ -266,7 +269,7 @@
                 </div>
             </div>
             <!-- Designation/Protection Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'protection'">
+            <div id="tabcontent_protection" class="aher-report-page" data-bind="if: activeSection() === 'protection'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/protection',
                     params: {
@@ -276,7 +279,7 @@
                 }"></div>
             </div>
             <!-- Assessments Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'assessments'">
+            <div id="tabcontent_assessments" class="aher-report-page" data-bind="if: activeSection() === 'assessments'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/assessments',
                     params: {
@@ -286,7 +289,7 @@
                 }"></div>
             </div>
             <!-- Images Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'images'">
+            <div id="tabcontent_images" class="aher-report-page" data-bind="if: activeSection() === 'images'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/images',
                     params: {
@@ -296,7 +299,7 @@
                 }"></div>
             </div>
             <!-- People Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'people'">
+            <div id="tabcontent_people" class="aher-report-page" data-bind="if: activeSection() === 'people'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/people',
                     params: {
@@ -306,7 +309,7 @@
                 }"></div>
             </div>
             <!-- Resources Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'resources'">
+            <div id="tabcontent_resources" class="aher-report-page" data-bind="if: activeSection() === 'resources'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/resources',
                     params: {
@@ -317,7 +320,7 @@
                 }"></div>
             </div>
              <!-- JSON Tab -->
-            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'">
+            <div id="tabcontent_json" class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'" aria-live="polite">
                 <div class="aher-flex-col" data-bind="component: {
                     name: 'views/components/reports/scenes/json',
                     params: {
@@ -326,7 +329,7 @@
                 }"></div>
             </div>
             <!-- Communication Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'communication'">
+            <div id="tabcontent_communication" class="aher-report-page" data-bind="if: activeSection() === 'communication'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/communication',
                     params: {

--- a/arches_her/templates/views/components/reports/monument.htm
+++ b/arches_her/templates/views/components/reports/monument.htm
@@ -20,14 +20,17 @@
     <div class="aher-report-anchor-container">
         <ol class="aher-report-anchors breadcrumb">
             <!-- ko foreach: {data: sections, as: 'section'} -->
-            <li tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function(){$parent.activeSection(section.id)}, css: {active: $parent.activeSection() === section.id}, text: section.title" class="aher-report-a"></li>
+            <li tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function(){$parent.activeSection(section.id)},
+                css: {active: $parent.activeSection() === section.id},
+                text: section.title, attr: {'aria-controls': 'tabcontent_' + section.id, 'aria-expanded': $parent.activeSection() === section.id ? 'true' : 'false'}"
+                class="aher-report-a" aria-expanded="false"></li>
             <!-- /ko -->
         </ol>
     </div>
     <div class="aher-tabbed-report">
         <div class="aher-tabbed-report-content">
             <!-- Names Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'name'">
+            <div id="tabcontent_name" class="aher-report-page" data-bind="if: activeSection() === 'name'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/name',
                     params: {
@@ -38,7 +41,7 @@
                 }"></div>
             </div>
             <!-- Description Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'description'">
+            <div id="tabcontent_description" class="aher-report-page" data-bind="if: activeSection() === 'description'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/description',
                     params: {
@@ -49,7 +52,7 @@
                 }"></div>
             </div>
             <!-- Classification Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications'">
+            <div id="tabcontent_classifications" class="aher-report-page" data-bind="if: activeSection() === 'classifications'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/classifications',
                     params: {
@@ -60,7 +63,7 @@
                 }"></div>
             </div>
             <!-- Location Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'location'">
+            <div id="tabcontent_location" class="aher-report-page" data-bind="if: activeSection() === 'location'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/location',
                     params: {
@@ -70,7 +73,7 @@
                 }"></div>
             </div>
             <!-- Designation/Protection Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'protection'">
+            <div id="tabcontent_protection" class="aher-report-page" data-bind="if: activeSection() === 'protection'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/protection',
                     params: {
@@ -80,7 +83,7 @@
                 }"></div>
             </div>
             <!-- Assessments Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'assessments'">
+            <div id="tabcontent_assessments" class="aher-report-page" data-bind="if: activeSection() === 'assessments'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/assessments',
                     params: {
@@ -90,7 +93,7 @@
                 }"></div>
             </div>
             <!-- Images Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'images'">
+            <div id="tabcontent_images" class="aher-report-page" data-bind="if: activeSection() === 'images'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/images',
                     params: {
@@ -100,7 +103,7 @@
                 }"></div>
             </div>
             <!-- People Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'people'">
+            <div id="tabcontent_people" class="aher-report-page" data-bind="if: activeSection() === 'people'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/people',
                     params: {
@@ -110,7 +113,7 @@
                 }"></div>
             </div>
             <!-- Resources Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'resources'">
+            <div id="tabcontent_resources" class="aher-report-page" data-bind="if: activeSection() === 'resources'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/resources',
                     params: {
@@ -121,7 +124,7 @@
                 }"></div>
             </div>
              <!-- JSON Tab -->
-            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'">
+            <div id="tabcontent_json" class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'" aria-live="polite">
                 <div class="aher-flex-col" data-bind="component: {
                     name: 'views/components/reports/scenes/json',
                     params: {
@@ -130,7 +133,7 @@
                 }"></div>
             </div>
             <!-- Communication Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'communication'">
+            <div id="tabcontent_communication" class="aher-report-page" data-bind="if: activeSection() === 'communication'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/communication',
                     params: {

--- a/arches_her/templates/views/components/reports/organization.htm
+++ b/arches_her/templates/views/components/reports/organization.htm
@@ -20,14 +20,17 @@
     <div class="aher-report-anchor-container">
         <ol class="aher-report-anchors breadcrumb">
             <!-- ko foreach: {data: sections, as: 'section'} -->
-            <li tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function(){$parent.activeSection(section.id)}, css: {active: $parent.activeSection() === section.id}, text: section.title" class="aher-report-a"></li>
+            <li tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function(){$parent.activeSection(section.id)},
+                css: {active: $parent.activeSection() === section.id},
+                text: section.title, attr: {'aria-controls': 'tabcontent_' + section.id, 'aria-expanded': $parent.activeSection() === section.id ? 'true' : 'false'}"
+                class="aher-report-a" aria-expanded="false"></li>
             <!-- /ko -->
         </ol>
     </div>
     <div class="aher-tabbed-report">
         <div class="aher-tabbed-report-content">
             <!-- Names Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'name'">
+            <div id="tabcontent_name" class="aher-report-page" data-bind="if: activeSection() === 'name'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/name',
                     params: {
@@ -39,7 +42,7 @@
             </div>
 
             <!-- Classification Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications'">
+            <div id="tabcontent_classifications" class="aher-report-page" data-bind="if: activeSection() === 'classifications'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/classifications',
                     params: {
@@ -57,7 +60,7 @@
                 }"></div>
             </div>
             <!-- Description Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'description'">
+            <div id="tabcontent_description" class="aher-report-page" data-bind="if: activeSection() === 'description'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/description',
                     params: {
@@ -68,7 +71,7 @@
                 }"></div>
             </div>
             <!-- Resources Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'resources'">
+            <div id="tabcontent_resources" class="aher-report-page" data-bind="if: activeSection() === 'resources'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/resources',
                     params: {
@@ -79,7 +82,7 @@
                 }"></div>
             </div>
             <!-- People Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'people'">
+            <div id="tabcontent_people" class="aher-report-page" data-bind="if: activeSection() === 'people'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/default',
                     params: {
@@ -88,7 +91,7 @@
                 }"></div>
             </div>
             <!-- Contact Details Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'contact'">
+            <div id="tabcontent_contact" class="aher-report-page" data-bind="if: activeSection() === 'contact'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/contact',
                     params: {
@@ -98,7 +101,7 @@
                 }"></div>
             </div>
             <!-- Location Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'location'">
+            <div id="tabcontent_location" class="aher-report-page" data-bind="if: activeSection() === 'location'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/location',
                     params: {
@@ -109,7 +112,7 @@
                 }"></div>
             </div>
              <!-- JSON Tab -->
-            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'">
+            <div id="tabcontent_json" class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'" aria-live="polite">
                 <div class="aher-flex-col" data-bind="component: {
                     name: 'views/components/reports/scenes/json',
                     params: {

--- a/arches_her/templates/views/components/reports/period.htm
+++ b/arches_her/templates/views/components/reports/period.htm
@@ -20,14 +20,17 @@
     <div class="aher-report-anchor-container">
         <ol class="aher-report-anchors breadcrumb">
             <!-- ko foreach: {data: sections, as: 'section'} -->
-            <li tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function(){$parent.activeSection(section.id)}, css: {active: $parent.activeSection() === section.id}, text: section.title" class="aher-report-a"></li>
+            <li tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function(){$parent.activeSection(section.id)},
+                css: {active: $parent.activeSection() === section.id},
+                text: section.title, attr: {'aria-controls': 'tabcontent_' + section.id, 'aria-expanded': $parent.activeSection() === section.id ? 'true' : 'false'}"
+                class="aher-report-a" aria-expanded="false"></li>
             <!-- /ko -->
         </ol>
     </div>
     <div class="aher-tabbed-report">
         <div class="aher-tabbed-report-content">
             <!-- Names Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'name'">
+            <div id="tabcontent_name" class="aher-report-page" data-bind="if: activeSection() === 'name'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/name',
                     params: {
@@ -38,7 +41,7 @@
                 }"></div>
             </div>
             <!-- Description Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'description'">
+            <div id="tabcontent_description" class="aher-report-page" data-bind="if: activeSection() === 'description'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/description',
                     params: {
@@ -50,7 +53,7 @@
             </div>
 
             <!-- Classification Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications'">
+            <div id="tabcontent_classifications" class="aher-report-page" data-bind="if: activeSection() === 'classifications'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/classifications',
                     params: {
@@ -61,7 +64,7 @@
                 }"></div>
             </div>
             <!-- Period Names Tab -->
-            <div class="afs-report-page" data-bind="if: activeSection() === 'period'">
+            <div id="tabcontent_period" class="afs-report-page" data-bind="if: activeSection() === 'period'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/default',
                     params: {
@@ -118,7 +121,7 @@
                 </div>
             </div>
             <!-- Location Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'location'">
+            <div id="tabcontent_location" class="aher-report-page" data-bind="if: activeSection() === 'location'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/location',
                     params: {
@@ -129,7 +132,7 @@
                 }"></div>
             </div>
              <!-- JSON Tab -->
-            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'">
+            <div id="tabcontent_json" class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'" aria-live="polite">
                 <div class="aher-flex-col" data-bind="component: {
                     name: 'views/components/reports/scenes/json',
                     params: {

--- a/arches_her/templates/views/components/reports/person.htm
+++ b/arches_her/templates/views/components/reports/person.htm
@@ -20,14 +20,17 @@
     <div class="aher-report-anchor-container">
         <ol class="aher-report-anchors breadcrumb">
             <!-- ko foreach: {data: sections, as: 'section'} -->
-            <li tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function(){$parent.activeSection(section.id)}, css: {active: $parent.activeSection() === section.id}, text: section.title" class="aher-report-a"></li>
+            <li tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function(){$parent.activeSection(section.id)},
+                css: {active: $parent.activeSection() === section.id},
+                text: section.title, attr: {'aria-controls': 'tabcontent_' + section.id, 'aria-expanded': $parent.activeSection() === section.id ? 'true' : 'false'}"
+                class="aher-report-a" aria-expanded="false"></li>
             <!-- /ko -->
         </ol>
     </div>
     <div class="aher-tabbed-report">
         <div class="aher-tabbed-report-content">
             <!-- Names Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'name'">
+            <div id="tabcontent_name" class="aher-report-page" data-bind="if: activeSection() === 'name'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/name',
                     params: {
@@ -37,7 +40,8 @@
                     }
                 }"></div>
             </div>
-            <div class="aher-report-page" data-bind="if: activeSection() === 'person-name'">
+            <!-- Person Name Tab -->
+            <div id="tabcontent_person-name" class="aher-report-page" data-bind="if: activeSection() === 'person-name'" aria-live="polite">
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title"><i tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.names)}, css: {'fa-angle-double-right': visible.names(), 'fa-angle-double-up': !visible.names()}" class="fa toggle"></i> {% trans "Names" %}</h2>
                     <span data-bind="if: cards.names && (!names().length || cards.names.cardinality == 'n')">
@@ -98,7 +102,7 @@
                 </div>
             </div>
             <!-- Description Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'description'">
+            <div id="tabcontent_description" class="aher-report-page" data-bind="if: activeSection() === 'description'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/description',
                     params: {
@@ -109,7 +113,7 @@
                 }"></div>
             </div>
             <!-- Resources Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'resources'">
+            <div id="tabcontent_resources" class="aher-report-page" data-bind="if: activeSection() === 'resources'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/resources',
                     params: {
@@ -120,7 +124,7 @@
                 }"></div>
             </div>
             <!-- People Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'people'">
+            <div id="tabcontent_people" class="aher-report-page" data-bind="if: activeSection() === 'people'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/people',
                     params: {
@@ -130,7 +134,7 @@
                 }"></div>
             </div>
             <!-- Images Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'images'">
+            <div id="tabcontent_images" class="aher-report-page" data-bind="if: activeSection() === 'images'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/images',
                     params: {
@@ -140,7 +144,7 @@
                 }"></div>
             </div>
             <!-- Contact Details Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'contact'">
+            <div id="tabcontent_contact" class="aher-report-page" data-bind="if: activeSection() === 'contact'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/contact',
                     params: {
@@ -156,7 +160,7 @@
                 }"></div>
             </div>
             <!-- documentation Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'documentation'">
+            <div id="tabcontent_documentation" class="aher-report-page" data-bind="if: activeSection() === 'documentation'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/documentation',
                     params: {
@@ -167,7 +171,7 @@
                 }"></div>
             </div>
             <!-- Location Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'location'">
+            <div id="tabcontent_location" class="aher-report-page" data-bind="if: activeSection() === 'location'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/location',
                     params: {
@@ -178,7 +182,7 @@
                 }"></div>
             </div>
              <!-- JSON Tab -->
-            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'">
+            <div id="tabcontent_json" class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'" aria-live="polite">
                 <div class="aher-flex-col" data-bind="component: {
                     name: 'views/components/reports/scenes/json',
                     params: {

--- a/arches_her/templates/views/components/reports/place.htm
+++ b/arches_her/templates/views/components/reports/place.htm
@@ -20,14 +20,17 @@
     <div class="aher-report-anchor-container">
         <ol class="aher-report-anchors breadcrumb">
             <!-- ko foreach: {data: sections, as: 'section'} -->
-            <li tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function(){$parent.activeSection(section.id)}, css: {active: $parent.activeSection() === section.id}, text: section.title" class="aher-report-a"></li>
+            <li tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function(){$parent.activeSection(section.id)},
+                css: {active: $parent.activeSection() === section.id},
+                text: section.title, attr: {'aria-controls': 'tabcontent_' + section.id, 'aria-expanded': $parent.activeSection() === section.id ? 'true' : 'false'}"
+                class="aher-report-a" aria-expanded="false"></li>
             <!-- /ko -->
         </ol>
     </div>
     <div class="aher-tabbed-report">
         <div class="aher-tabbed-report-content">
             <!-- Names Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'name'">
+            <div id="tabcontent_name" class="aher-report-page" data-bind="if: activeSection() === 'name'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/name',
                     params: {
@@ -38,7 +41,7 @@
                 }"></div>
             </div>
             <!-- Description Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'description'">
+            <div id="tabcontent_description" class="aher-report-page" data-bind="if: activeSection() === 'description'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/description',
                     params: {
@@ -48,7 +51,7 @@
                 }"></div>
             </div>
             <!-- Classification Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications'">
+            <div id="tabcontent_classifications" class="aher-report-page" data-bind="if: activeSection() === 'classifications'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/classifications',
                     params: {
@@ -59,7 +62,7 @@
                 }"></div>
             </div>
             <!-- Location Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'location'">
+            <div id="tabcontent_location" class="aher-report-page" data-bind="if: activeSection() === 'location'" aria-live="polite">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/location',
                     params: {
@@ -70,7 +73,7 @@
                 }"></div>
             </div>
              <!-- JSON Tab -->
-            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'">
+            <div id="tabcontent_json" class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'" aria-live="polite">
                 <div class="aher-flex-col" data-bind="component: {
                     name: 'views/components/reports/scenes/json',
                     params: {


### PR DESCRIPTION
Fixes issue with screen reader when navigating report tabs, affects all reports. Added required aria-controls/expanded values to identify what is being displayed and aria-live to force opened content to be read out. Tested with NVDA, now reads as expected.

Fixes #1267 