### PR TITLE
Make associated cons node visible

### DIFF
--- a/arches_her/pkg/graphs/resource_models/Consultation.json
+++ b/arches_her/pkg/graphs/resource_models/Consultation.json
@@ -299,7 +299,7 @@
                     },
                     "nodegroup_id": "4912e29f-edf2-11eb-bf42-a87eeabdefba",
                     "sortorder": 19,
-                    "visible": false
+                    "visible": true
                 },
                 {
                     "active": true,


### PR DESCRIPTION
Despite the Associated Consultations node in the Consultations model showing visible in the resource model UI, the node would not show up in the resource editor.

Closes https://github.com/archesproject/arches-her/issues/1287