### PR TITLE
Fix length of "Resource Referenced By" table 

### DIFF
--- a/arches_her/media/js/views/components/reports/scenes/referenced-by.js
+++ b/arches_her/media/js/views/components/reports/scenes/referenced-by.js
@@ -70,6 +70,8 @@ define([
                         // error
                     });
             };
+
+            self.getRelatedResources();
         },
         template: ReferencedByTemplate
     });

--- a/arches_her/templates/views/components/reports/scenes/referenced-by.htm
+++ b/arches_her/templates/views/components/reports/scenes/referenced-by.htm
@@ -12,7 +12,7 @@
     <div class="aher-nodata-note">{% trans "No resource referenced by for this resource" %}</div>
     <!-- /ko -->
 
-    <!-- ko if: getRelatedResources() -->
+    <!-- ko if: relations().length -->
     <div class="aher-report-subsection">
         <div class="firstchild-container">
             <div class="aher-table">

--- a/arches_her/templates/views/components/reports/scenes/referenced-by.htm
+++ b/arches_her/templates/views/components/reports/scenes/referenced-by.htm
@@ -8,11 +8,11 @@
 <!-- Collapsible content -->
 <div data-bind="visible: visible.referencedBy" class="aher-report-collapsible-container pad-lft">
 
-    <!-- ko ifnot: getRelatedResources() -->
+    <!-- ko if: relations().length == 0 -->
     <div class="aher-nodata-note">{% trans "No resource referenced by for this resource" %}</div>
     <!-- /ko -->
 
-    <!-- ko if: relations().length -->
+    <!-- ko if: relations().length > 0 -->
     <div class="aher-report-subsection">
         <div class="firstchild-container">
             <div class="aher-table">


### PR DESCRIPTION
Addresses #1277

The "Resource Referenced By" table didn't have a fixed length because the rows were added asynchronously, which was causing issues with paging and thus the other resource association tables.

Changing `<!-- ko if: getRelatedResources() -->` to `<!-- ko if: relations().length -->` seems to give the table a correct length, allowing the others to render properly.