### PR TITLE
#1291 Add tag to password_reset_subject.txt

### DIFF
--- a/arches_her/templates/registration/password_reset_subject.txt
+++ b/arches_her/templates/registration/password_reset_subject.txt
@@ -1,1 +1,1 @@
-Password reset for 
+Password reset for {{ site_name }}


### PR DESCRIPTION
Closes #1291 

The site_name renders the host name in the subject line rather than the app name - this is in keeping with the text within the password reset email.