### PR TITLE
Fix for ajax console error when deleting tile/row from table

### DIFF
--- a/arches_her/media/js/utils/report.js
+++ b/arches_her/media/js/utils/report.js
@@ -40,12 +40,13 @@ define([
             return $.ajax({
                 type: "DELETE",
                 url: arches.urls.tile,
-                data: JSON.stringify(tile.getData())
-            }).success(() => {
-                const tiles = card.tiles();
-                const tileIndex = tiles.indexOf(tile);
-                tiles.splice(tileIndex, 1);
-                card.tiles(tiles);
+                data: JSON.stringify(tile.getData()),
+                success: () => {
+                    const tiles = card.tiles();
+                    const tileIndex = tiles.indexOf(tile);
+                    tiles.splice(tileIndex, 1);
+                    card.tiles(tiles);
+                }
             });
         }
         throw Error("Couldn't delete; tile was not found.")


### PR DESCRIPTION
Closes: #1292 

The change in jquery versions between Arches version 6 and 7 means that the `.success` method no longer works; now success is a part of the ajax call.

The deletion ajax call now works, and the deletion is reflected in the table and node tree.