### PR TITLE
Add back the related Application Areas table to Consultation report

### DIFF
--- a/arches_her/media/js/views/components/reports/consultation.js
+++ b/arches_her/media/js/views/components/reports/consultation.js
@@ -59,7 +59,7 @@ define([
             self.resourcesDataConfig = {
                 assets: 'related monuments and areas',
                 files: 'file(s)',
-                relatedApplicationArea: undefined,
+                relatedApplicationArea: 'consultation area',
                 consultation: 'associated consultations',
                 actors: undefined,
                 archive: undefined,

--- a/arches_her/media/js/views/components/reports/scenes/resources.js
+++ b/arches_her/media/js/views/components/reports/scenes/resources.js
@@ -39,6 +39,8 @@ function (_, ko, arches, reportUtils, ResourcesTemplate) {
 
             self.applicationAreaTableConfig = {
                 ...self.defaultTableConfig,
+                paging: true,
+                searching: true,
                 columns: Array(2).fill(null)
             };
 

--- a/arches_her/templates/views/components/reports/scenes/resources.htm
+++ b/arches_her/templates/views/components/reports/scenes/resources.htm
@@ -376,6 +376,10 @@
         <i tabindex="0" data-bind="onEnterkeyClick, onSpaceClick, click: function() {toggleVisibility(visible.applicationArea)}, css: {'fa-angle-double-right': visible.applicationArea(), 'fa-angle-double-up': !visible.applicationArea()}, attr: {'aria-expanded': visible.applicationArea() ? 'false' : 'true' }" class="fa toggle" aria-label="Expand/collapse Related Application Areas section"></i>
         {% trans "Related Application Areas" %}
     </h2>
+    <!-- ko if: cards.relatedApplicationArea -->
+    <a href="#" data-bind="click: function(){addNewTile(cards.relatedApplicationArea)}"  class="aher-report-a"><i class="fa fa-mail-reply"></i> {% trans "Add Application Area" %}</a>
+    <!-- /ko -->
+
     <!-- Collapsible content -->
     <div data-bind="visible: visible.applicationArea" class="aher-report-collapsible-container pad-lft">
         <!-- ko ifnot: applicationArea().length -->
@@ -407,6 +411,9 @@
                                     <div data-bind="if: $parent.cards.relatedApplicationArea">
                                         <a href="#" data-bind="onEnterkeyClick, onSpaceClick, click: function() {$parent.editTile(tileid, $parent.cards.relatedApplicationArea)}">
                                             <i class="fa fa-mail-reply"></i>
+                                        </a>
+                                        <a href="#" data-bind="onEnterkeyClick, onSpaceClick, click: $parent.deleteTile.bind($data, tileid, $parent.cards.relatedApplicationArea)">
+                                            <i class="fa fa-trash"></i>
                                         </a>
                                     </div>
                                 </td>


### PR DESCRIPTION
Addresses #1286

Adds table of Related Application Area back to the consultation report, e.g.
![image](https://github.com/user-attachments/assets/92ee3792-b3dd-441e-b714-50a673e67aca)

