### PR TITLE
Updates invalid default node values with valid values used in other graph files

### DIFF
--- a/arches_her/pkg/graphs/branches/Location Data.json
+++ b/arches_her/pkg/graphs/branches/Location Data.json
@@ -557,7 +557,7 @@
                 {
                     "card_id": "b1d2cd15-f446-11eb-8b1c-a87eeabdefba",
                     "config": {
-                        "defaultValue": "b022dbc0-b722-4e12-a675-12fca24ddffa",
+                        "defaultValue": "1d5c7465-7225-4bca-b1df-045a86e286b2",
                         "i18n_properties": [
                             "placeholder"
                         ],
@@ -652,7 +652,7 @@
                 {
                     "card_id": "b1d2cd15-f446-11eb-8b1c-a87eeabdefba",
                     "config": {
-                        "defaultValue": "b022dbc0-b722-4e12-a675-12fca24ddffa",
+                        "defaultValue": "c6dd5482-6687-44ae-bb54-7d49e084664a",
                         "i18n_properties": [
                             "placeholder"
                         ],
@@ -674,7 +674,7 @@
                 {
                     "card_id": "b1d2cd15-f446-11eb-8b1c-a87eeabdefba",
                     "config": {
-                        "defaultValue": "b022dbc0-b722-4e12-a675-12fca24ddffa",
+                        "defaultValue": "65ef7ae0-6a6b-4fac-9324-41dd8e712880",
                         "i18n_properties": [
                             "placeholder"
                         ],
@@ -2618,7 +2618,7 @@
                 {
                     "card_id": "b1d2cd0f-f446-11eb-b119-a87eeabdefba",
                     "config": {
-                        "defaultValue": "3fcc7154-55b0-42f4-8184-c07c47f75cf4",
+                        "defaultValue": "e6cf2f57-55f1-4598-ab1a-1f0c4285b9b2",
                         "i18n_properties": [
                             "placeholder"
                         ],
@@ -2731,7 +2731,7 @@
                 {
                     "card_id": "b1d2cd0f-f446-11eb-b119-a87eeabdefba",
                     "config": {
-                        "defaultValue": "b153a28a-53f1-49d7-96c4-5e8fa076b52e",
+                        "defaultValue": "dbc18bc0-ec10-4623-b866-52ece47d9780",
                         "i18n_properties": [
                             "placeholder"
                         ],


### PR DESCRIPTION
Updates default values of some nodes in the in the Location Data branch file (not where used in resource models) with valid values. These are taken from the `pkg/graphs/branches/Geometry.json` and `pkg/graphs/branches/Area.json` files which are valid.

![image](https://github.com/user-attachments/assets/fed2f9dd-3d8a-4b90-b41e-57a0f2b7a920)


fixes #1307