### PR TITLE
Add Outcome Notes nodes to Consultation model

### DIFF
--- a/arches_her/pkg/graphs/resource_models/Consultation.json
+++ b/arches_her/pkg/graphs/resource_models/Consultation.json
@@ -1684,6 +1684,28 @@
                     "widget_id": "10000000-0000-0000-0000-000000000002"
                 },
                 {
+                    "card_id": "8d41e4c5-a250-11e9-88ad-00224800b26d",
+                    "config": {
+                        "defaultValue": "6fbe3775-e51d-4f90-af53-5695dd204c9a",
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "Outcome Note Metatype",
+                        "options": [],
+                        "placeholder": {
+                            "en": "Select an option"
+                        }
+                    },
+                    "id": "42cead7a-3a49-45ed-9efc-42eae26d9e34",
+                    "label": {
+                        "en": "Outcome Note Metatype"
+                    },
+                    "node_id": "a4690b52-654d-11ef-be85-00155db9341b",
+                    "sortorder": 6,
+                    "visible": false,
+                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                },
+                {
                     "card_id": "8d41e4a1-a250-11e9-9c34-00224800b26d",
                     "config": {
                         "defaultValue": {
@@ -6812,6 +6834,34 @@
                     "widget_id": "10000000-0000-0000-0000-000000000002"
                 },
                 {
+                    "card_id": "8d41e4c5-a250-11e9-88ad-00224800b26d",
+                    "config": {
+                        "defaultValue": {
+                            "en": {
+                                "direction": "ltr"
+                            }
+                        },
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "Outcome Note",
+                        "maxLength": null,
+                        "placeholder": {
+                            "en": "Enter text"
+                        },
+                        "uneditable": false,
+                        "width": "100%"
+                    },
+                    "id": "c992446f-90bf-45c4-9aa8-087557853ccc",
+                    "label": {
+                        "en": "Outcome Note"
+                    },
+                    "node_id": "cce2a80e-654d-11ef-be85-00155db9341b",
+                    "sortorder": 4,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000005"
+                },
+                {
                     "card_id": "9ba968c4-2f53-11eb-abb5-acde48001122",
                     "config": {
                         "defaultValue": {
@@ -7196,6 +7246,28 @@
                     "sortorder": 2,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000004"
+                },
+                {
+                    "card_id": "8d41e4c5-a250-11e9-88ad-00224800b26d",
+                    "config": {
+                        "defaultValue": "daa4cddc-8636-4842-b836-eb2e10aabe18",
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "Outcome Note Type",
+                        "options": [],
+                        "placeholder": {
+                            "en": "Select an option"
+                        }
+                    },
+                    "id": "d5bae2e5-6d50-4977-9880-044801fd1305",
+                    "label": {
+                        "en": "Outcome Note Type"
+                    },
+                    "node_id": "79af2bc6-654d-11ef-be85-00155db9341b",
+                    "sortorder": 5,
+                    "visible": false,
+                    "widget_id": "10000000-0000-0000-0000-000000000002"
                 },
                 {
                     "card_id": "caf5bff3-a3d7-11e9-b521-00224800b26d",
@@ -8425,6 +8497,15 @@
                 },
                 {
                     "description": null,
+                    "domainnode_id": "3a653406-654d-11ef-aa12-00155db9341b",
+                    "edgeid": "608b072a-93f3-4659-bc72-c50cc106bf58",
+                    "graph_id": "8d41e49e-a250-11e9-9eab-00224800b26d",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "79af2bc6-654d-11ef-be85-00155db9341b"
+                },
+                {
+                    "description": null,
                     "domainnode_id": "62463954-3ee4-11eb-af5d-f875a44e0e11",
                     "edgeid": "62474aa8-3ee4-11eb-9851-f875a44e0e11",
                     "graph_id": "8d41e49e-a250-11e9-9eab-00224800b26d",
@@ -9088,6 +9169,15 @@
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
                     "rangenode_id": "a43779cc-95c0-11ea-b3f1-f875a44e0e11"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "8d41e4c3-a250-11e9-b348-00224800b26d",
+                    "edgeid": "a4e2b52c-6c45-4d98-a853-3015fd8e8932",
+                    "graph_id": "8d41e49e-a250-11e9-9eab-00224800b26d",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P129i_is_subject_of",
+                    "rangenode_id": "3a653406-654d-11ef-aa12-00155db9341b"
                 },
                 {
                     "description": null,
@@ -10162,6 +10252,15 @@
                 },
                 {
                     "description": null,
+                    "domainnode_id": "3a653406-654d-11ef-aa12-00155db9341b",
+                    "edgeid": "cbd55d6e-d5ba-414f-b409-adf362112374",
+                    "graph_id": "8d41e49e-a250-11e9-9eab-00224800b26d",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
+                    "rangenode_id": "cce2a80e-654d-11ef-be85-00155db9341b"
+                },
+                {
+                    "description": null,
                     "domainnode_id": "82b3ed68-8882-11ea-8ff6-f875a44e0e11",
                     "edgeid": "d0c9c724-95be-11ea-85e2-f875a44e0e11",
                     "graph_id": "8d41e49e-a250-11e9-9eab-00224800b26d",
@@ -10339,6 +10438,15 @@
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
                     "rangenode_id": "f76b68f4-9534-11ea-b94c-f875a44e0e11"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "79af2bc6-654d-11ef-be85-00155db9341b",
+                    "edgeid": "f78bf698-963e-4277-abe7-9882b24d4206",
+                    "graph_id": "8d41e49e-a250-11e9-9eab-00224800b26d",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "a4690b52-654d-11ef-be85-00155db9341b"
                 },
                 {
                     "description": null,
@@ -11237,6 +11345,29 @@
                     "nodeid": "27b4d1bb-938c-11ea-8e1d-f875a44e0e11",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "outcome_notes",
+                    "config": {
+                        "en": ""
+                    },
+                    "datatype": "semantic",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "8d41e49e-a250-11e9-9eab-00224800b26d",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Outcome Notes",
+                    "nodegroup_id": "8d41e4c3-a250-11e9-b348-00224800b26d",
+                    "nodeid": "3a653406-654d-11ef-aa12-00155db9341b",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E33_Linguistic_Object",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P129i_is_subject_of",
                     "sortorder": 0,
                     "sourcebranchpublication_id": null
                 },
@@ -14046,6 +14177,29 @@
                     "sourcebranchpublication_id": null
                 },
                 {
+                    "alias": "outcome_note_type",
+                    "config": {
+                        "rdmCollection": "0ff39ed3-cc95-4c60-9321-6d4e65fb1f2d"
+                    },
+                    "datatype": "concept",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "8d41e49e-a250-11e9-9eab-00224800b26d",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": false,
+                    "istopnode": false,
+                    "name": "Outcome Note Type",
+                    "nodegroup_id": "8d41e4c3-a250-11e9-b348-00224800b26d",
+                    "nodeid": "79af2bc6-654d-11ef-be85-00155db9341b",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
                     "alias": "attendee_metatype",
                     "config": {
                         "rdmCollection": "1e63c514-eb9d-48d3-94b5-35e060e5f368"
@@ -14729,6 +14883,29 @@
                     "name": "Proposal Description Metatype",
                     "nodegroup_id": "1b0e15e9-8864-11ea-b5f3-f875a44e0e11",
                     "nodeid": "a43779cc-95c0-11ea-b3f1-f875a44e0e11",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "outcome_note_metatype",
+                    "config": {
+                        "rdmCollection": "1e63c514-eb9d-48d3-94b5-35e060e5f368"
+                    },
+                    "datatype": "concept",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "8d41e49e-a250-11e9-9eab-00224800b26d",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": false,
+                    "istopnode": false,
+                    "name": "Outcome Note Metatype",
+                    "nodegroup_id": "8d41e4c3-a250-11e9-b348-00224800b26d",
+                    "nodeid": "a4690b52-654d-11ef-be85-00155db9341b",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
                     "sortorder": 0,
@@ -17461,6 +17638,29 @@
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
                     "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "outcome_note",
+                    "config": {
+                        "en": ""
+                    },
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": true,
+                    "fieldname": "Outc_note",
+                    "graph_id": "8d41e49e-a250-11e9-9eab-00224800b26d",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Outcome Note",
+                    "nodegroup_id": "8d41e4c3-a250-11e9-b348-00224800b26d",
+                    "nodeid": "cce2a80e-654d-11ef-be85-00155db9341b",
+                    "ontologyclass": "http://www.w3.org/2000/01/rdf-schema#Literal",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
+                    "sortorder": 1,
                     "sourcebranchpublication_id": null
                 },
                 {


### PR DESCRIPTION
Addresses #1319

Adds the following nodes to the Outcome nodegroup:
![image](https://github.com/user-attachments/assets/6ef3924a-3b25-4ad8-833e-f227f286a30e)
I used the Audit metadata notes nodes and the Artefact discovery notes as a reference for the convention of adding notes nodes.


The card added is just the rich-text note:
![image](https://github.com/user-attachments/assets/efe6283c-de8a-4f33-9837-8f6ac536de12)
