### PR TITLE
Fix to hide map buttons and display action buttons

### DIFF
--- a/arches_her/media/css/project.css
+++ b/arches_her/media/css/project.css
@@ -824,7 +824,7 @@ table.report-tabular-card {
     margin-top: 10px;
 }
 
-.tabbed-workflow-step-body .workbench-card-sidepanel .install-buttons {
+.tabbed-workflow-step-body .workbench-card-sidepanel .install-buttons:not(.tabbed-workflow-step-body .workbench-card-sidepanel .create-resource-instance-card-component .install-buttons) {
     display: none;
 }
 
@@ -1055,4 +1055,10 @@ span.rp-tile-title {
 
 .ep-notifs-panel{
     height: 100%;
+}
+
+/* Ensures Consultation > Related Application Area > Create new application area ... - displays correctly */
+
+.workbench-card-sidebar {
+    z-index: 245;
 }


### PR DESCRIPTION
This change ensures correct z-index for the map filter buttons so that they aren't displayed over the top of the Create New Application Area panel, when creating a Consultation Workflow. Also to ensure that the previously hidden action buttons are not hid on this particular panel.

**Note: This needs to be tested by a tester before merging, which I will arrange once approved**

Fixes #1321 