### PR TITLE
Fix formatting in the report section for assessment of significance

### DIFF
--- a/arches_her/media/js/views/components/reports/consultation.js
+++ b/arches_her/media/js/views/components/reports/consultation.js
@@ -257,7 +257,7 @@ define([
             const assessmentOfSignificanceNode = self.getRawNodeValue(self.resource(), 'assessment of significance');
             if(Array.isArray(assessmentOfSignificanceNode)){
                 self.assessmentOfSignificance(assessmentOfSignificanceNode.map(node => {
-                    const notes = self.getNodeValue(node, 'notes');
+                    const notes = self.getNodeValue(node, 'notes', '@display_value');
                     const tileid = self.getTileId(node);
                     return {notes, tileid};
                 }));

--- a/arches_her/templates/views/components/reports/consultation.htm
+++ b/arches_her/templates/views/components/reports/consultation.htm
@@ -475,7 +475,7 @@
                                         </thead>
                                         <tbody data-bind="dataTablesForEach: { data: assessmentOfSignificance, dataTableOptions: createTableConfig(2)}">
                                             <tr>
-                                                <td data-bind="text: notes"></td>
+                                                <td data-bind="html: notes"></td>
                                                 <td class="aher-table-control">
                                                     <div data-bind="if: $parent.cards['assessment of significance']">
                                                         <a href="#" data-bind="onEnterkeyClick, onSpaceClick, click: function() {$parent.editTile(tileid, $parent.cards['assessment of significance'])}">


### PR DESCRIPTION
The rich text formatting for area of significance was not being shown in the consultation report. See issue: https://github.com/archesproject/arches-her/issues/1352 

This fix now passes the formatting to the html template, and ensures it is shown as html. 

Closes: https://github.com/archesproject/arches-her/issues/1352