### PR TITLE
Correct spelling mistakes in Consultation and Site Visit workflows

### DIFF
--- a/arches_her/media/js/views/components/plugins/active-consultations.js
+++ b/arches_her/media/js/views/components/plugins/active-consultations.js
@@ -47,7 +47,7 @@ define([
                 self.getConsultations();
                 self.searched = false;
             };
-            this.activeConsulationConfig = { // could pass this into GET req
+            this.activeConsultationConfig = { // could pass this into GET req
                 "nodes":{
                     "Geospatial Coordinates":"b949053a-184f-11eb-ac4a-f875a44e0e11",
                     "Consultation Name":"4ad69684-951f-11ea-b5c3-f875a44e0e11",
@@ -71,7 +71,7 @@ define([
                 }
             };
             this.sortOptions = ko.observableArray([]);
-            Object.keys(this.activeConsulationConfig["sort config"]).forEach(function(key) {
+            Object.keys(this.activeConsultationConfig["sort config"]).forEach(function(key) {
                 self.sortOptions.push(key);
             });
             this.orderByOption.subscribe(function(val) {
@@ -197,7 +197,7 @@ define([
                         "page": self.page(),
                         "order": self.orderByOption(),
                         "keyword": self.keyword()
-                        // "config": self.activeConsulationConfig
+                        // "config": self.activeConsultationConfig
                     },
                     context: self,
                     success: function(responseText, status, response){

--- a/arches_her/media/js/views/components/plugins/consultation-workflow.js
+++ b/arches_her/media/js/views/components/plugins/consultation-workflow.js
@@ -168,7 +168,7 @@ define([
                     ],
                 },
                 {
-                    title: 'Add Consulation Complete',
+                    title: 'Add Consultation Complete',
                     name: 'consultation-complete',
                     description: 'Choose an option below',
                     layoutSections: [

--- a/arches_her/media/js/views/components/plugins/site-visit.js
+++ b/arches_her/media/js/views/components/plugins/site-visit.js
@@ -21,7 +21,7 @@ define([
                     required: true,
                     informationboxdata: {
                         heading: 'Site Visit Details',
-                        text: 'Select a consultation and enter datails for the site visit',
+                        text: 'Select a consultation and enter details for the site visit',
                     },
                     layoutSections: [
                         {

--- a/arches_her/media/js/views/components/reports/scenes/resources.js
+++ b/arches_her/media/js/views/components/reports/scenes/resources.js
@@ -105,7 +105,7 @@ function (_, ko, arches, reportUtils, ResourcesTemplate) {
                     }));
                 }
 
-                const userAvailableConsulationCards = () => {
+                const userAvailableConsultationCards = () => {
                         return $.ajax({
                             url: arches.urls.api_card + self.dataConfig.resourceinstanceid,
                             context: this,
@@ -119,7 +119,7 @@ function (_, ko, arches, reportUtils, ResourcesTemplate) {
 
 
                 if(self.dataConfig.resourceinstanceid){
-                    userAvailableConsulationCards().then(function(cards_response){
+                    userAvailableConsultationCards().then(function(cards_response){
                         if(cards_response !== false){
                             var card_names = []
                             for(card in cards_response.cards){

--- a/arches_her/templates/views/components/reports/scenes/description.htm
+++ b/arches_her/templates/views/components/reports/scenes/description.htm
@@ -118,7 +118,7 @@
     <div data-bind="visible: visible.audience" class="aher-report-collapsible-container pad-lft">
 
         <!-- ko ifnot: audience().length -->
-        <div class="aher-nodata-note">No hertiage/area/artifacts for this resource</div>
+        <div class="aher-nodata-note">No monuments/areas/artefacts for this resource</div>
         <!-- /ko -->
 
         <!-- ko if: audience().length -->

--- a/arches_her/templates/views/components/reports/scenes/resources.htm
+++ b/arches_her/templates/views/components/reports/scenes/resources.htm
@@ -261,7 +261,7 @@
     <div data-bind="visible: visible.assets" class="aher-report-collapsible-container pad-lft">
 
         <!-- ko ifnot: assets().length -->
-        <div class="aher-nodata-note">No heritage assets/areas/artefacts for this resource</div>
+        <div class="aher-nodata-note">No monuments/areas/artefacts for this resource</div>
         <!-- /ko -->
 
         <!-- ko if: assets().length -->


### PR DESCRIPTION
Closes #1385 

The spelling "Consulation" is also found in:
- `active-consultations.js` 
- `resources.js`
- `Consultation.json`

While the javascript files can be replaced, the Consultation model cannot - if we wanted to change it we'd need a model migration.