### PR TITLE
Add migration for including "show": true to Accessibility Statement and Active Consultations plugins

### DIFF
--- a/arches_her/migrations/0004_update_plugins.py
+++ b/arches_her/migrations/0004_update_plugins.py
@@ -1,0 +1,33 @@
+from django.db import migrations, models
+from django.utils.translation import gettext as _
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("arches_her", "0003_add_bng_search_view")]
+
+    def update_plugins(apps, scheme_editor):
+        Plugin = apps.get_model("models", "Plugin")
+
+        active_consultations = Plugin.objects.get(pluginid="76a27df9-6f16-47ed-bd47-bb95c0fe7173")
+        active_consultations.config["show"] = True
+        active_consultations.save()
+
+        accessibility_statement = Plugin.objects.get(pluginid="8688eaf9-3605-4384-823c-d01c0d210f82")
+        accessibility_statement.config["show"] = True
+        accessibility_statement.save()
+
+    def remove_plugin_updates(apps, scheme_editor):
+        Plugin = apps.get_model("models", "Plugin")
+
+        active_consultations = Plugin.objects.get(pluginid="76a27df9-6f16-47ed-bd47-bb95c0fe7173")
+        active_consultations.config.pop("show", None)
+        active_consultations.save()
+
+        accessibility_statement = Plugin.objects.get(pluginid="8688eaf9-3605-4384-823c-d01c0d210f82")
+        accessibility_statement.config.pop("show", None)
+        accessibility_statement.save()
+
+    operations = [
+        migrations.RunPython(update_plugins, remove_plugin_updates),
+    ]

--- a/arches_her/migrations/0004_update_plugins.py
+++ b/arches_her/migrations/0004_update_plugins.py
@@ -6,28 +6,21 @@ class Migration(migrations.Migration):
 
     dependencies = [("arches_her", "0003_add_bng_search_view")]
 
-    def update_plugins(apps, scheme_editor):
-        Plugin = apps.get_model("models", "Plugin")
+    # accessibility plugin = '8688eaf9-3605-4384-823c-d01c0d210f82'
+    # active consultations = '76a27df9-6f16-47ed-bd47-bb95c0fe7173'
 
-        active_consultations = Plugin.objects.get(pluginid="76a27df9-6f16-47ed-bd47-bb95c0fe7173")
-        active_consultations.config["show"] = True
-        active_consultations.save()
+    add_plugin_show_true = """
+        UPDATE plugins 
+        SET config = jsonb_set(config, '{show}', 'true'::jsonb, true) 
+        WHERE pluginid in ('76a27df9-6f16-47ed-bd47-bb95c0fe7173','8688eaf9-3605-4384-823c-d01c0d210f82');
+        """
 
-        accessibility_statement = Plugin.objects.get(pluginid="8688eaf9-3605-4384-823c-d01c0d210f82")
-        accessibility_statement.config["show"] = True
-        accessibility_statement.save()
-
-    def remove_plugin_updates(apps, scheme_editor):
-        Plugin = apps.get_model("models", "Plugin")
-
-        active_consultations = Plugin.objects.get(pluginid="76a27df9-6f16-47ed-bd47-bb95c0fe7173")
-        active_consultations.config.pop("show", None)
-        active_consultations.save()
-
-        accessibility_statement = Plugin.objects.get(pluginid="8688eaf9-3605-4384-823c-d01c0d210f82")
-        accessibility_statement.config.pop("show", None)
-        accessibility_statement.save()
+    remove_plugin_show = """
+        UPDATE plugins 
+        SET config = config - 'show' 
+        WHERE pluginid in ('76a27df9-6f16-47ed-bd47-bb95c0fe7173','8688eaf9-3605-4384-823c-d01c0d210f82');
+        """
 
     operations = [
-        migrations.RunPython(update_plugins, remove_plugin_updates),
+        migrations.RunSQL(add_plugin_show_true, remove_plugin_show),
     ]


### PR DESCRIPTION
Closes #1390 

Adds a 0004 migration file for adding "show" to the plugin config.

The one major issue still outstanding is that `plugin.config.pop("show", None)` and `plugin.save()` isn't actually saving the removed property from the config. Printing the config after removal does reveal that the show key has been removed, so I'm not sure why saving isn't working.

Attempting removal with `del` and `I18n_String.__delitem__(x.config, "show")` also didn't work