### PR TITLE
Adds turf buffer units object

### DIFF
--- a/arches_her/media/js/views/components/search/bng-filter.js
+++ b/arches_her/media/js/views/components/search/bng-filter.js
@@ -546,7 +546,7 @@ define([
 
                 try {
                     self.map().getSource('grid-square')?.setData(geoJSON);
-                    bounds_geojson = isPoint ? turf.buffer(bounds_geojson, 100, 'meters') : bounds_geojson;
+                    bounds_geojson = isPoint ? turf.buffer(bounds_geojson, 100, {units: 'meters'}) : bounds_geojson;
                     var extent = geojsonExtent(bounds_geojson);
                     var bounds = new self.mapboxgl.LngLatBounds(extent);
                     self.map().fitBounds(bounds, {


### PR DESCRIPTION
This brings turf.buffer syntax inline with the correct syntax: https://turfjs.org/docs/api/buffer

'meters' is now wrapped in an object: `{units: 'meters'}`.

Closes https://github.com/archesproject/arches-her/issues/1403