### PR TITLE
Move background colour setting from body to .landing-page

### DIFF
--- a/arches_her/media/css/project-files/_landing.scss
+++ b/arches_her/media/css/project-files/_landing.scss
@@ -2,12 +2,9 @@
 @import "project-functions";
 @import "project-variables";
 
-body {
-    background-color: $backgrounds;
-}
-
 .landing-page {
-	/* General - Start*/
+    /* General - Start*/
+    background-color: $backgrounds;
     font-family: $font-family-main;
 	font-size: 1.125rem;
 	font-weight: 300;


### PR DESCRIPTION
As discussed in https://github.com/archesproject/arches-her/issues/1389, background colour was being set on body, so was impacting other parts of the site. 

We discussed whether removing this setting entirely looked better for the index page, but either way, this is something that should be controlled at the level of .landing-page, not body. So for now, I've just moved the setting into the landing-page class, which means we no longer see the erroneous white stripe on the other core Arches pages. 