### PR TITLE
Adds referenced-by scene to all reports

### DIFF
--- a/arches_her/media/js/views/components/reports/activity.js
+++ b/arches_her/media/js/views/components/reports/activity.js
@@ -7,6 +7,7 @@ define([
     'utils/report',
     'templates/views/components/reports/activity.htm',
     'views/components/reports/scenes/name',
+    'views/components/reports/scenes/referenced-by',
     'views/components/reports/scenes/description',
     'views/components/reports/scenes/json',
     'views/components/reports/scenes/classifications',
@@ -38,6 +39,7 @@ define([
             self.activityArchive = ko.observableArray();
             self.displayname = ko.observable(ko.unwrap(self.reportMetadata)?.displayname);
             self.activeSection = ko.observable('name');
+            self.resourceinstanceid = ko.observable(params.report?.report_json?.resourceinstanceid);
 
             self.activityArchiveConfig = {
                 ...self.defaultTableConfig,

--- a/arches_her/media/js/views/components/reports/area.js
+++ b/arches_her/media/js/views/components/reports/area.js
@@ -7,6 +7,7 @@ define([
     'utils/report',
     'templates/views/components/reports/area.htm',
     'views/components/reports/scenes/name',
+    'views/components/reports/scenes/referenced-by',
     'views/components/reports/scenes/assessments',
     'views/components/reports/scenes/images',
     'views/components/reports/scenes/people',
@@ -39,6 +40,7 @@ define([
             self.resource = ko.observable(self.reportMetadata()?.resource);
             self.displayname = ko.observable(ko.unwrap(self.reportMetadata)?.displayname);
             self.activeSection = ko.observable('name');
+            self.resourceinstanceid = ko.observable(params.report?.report_json?.resourceinstanceid);
 
             self.nameDataConfig = {
                 name: 'area',

--- a/arches_her/media/js/views/components/reports/artefact.js
+++ b/arches_her/media/js/views/components/reports/artefact.js
@@ -7,6 +7,7 @@ define([
     'utils/report',
     'templates/views/components/reports/artefact.htm',
     'views/components/reports/scenes/name',
+    'views/components/reports/scenes/referenced-by',
     'views/components/reports/scenes/json',
     'views/components/reports/scenes/archive',
     'bindings/reports'
@@ -47,6 +48,7 @@ define([
             self.resource = ko.observable(self.reportMetadata()?.resource);
             self.displayname = ko.observable(ko.unwrap(self.reportMetadata)?.displayname);
             self.activeSection = ko.observable('name');
+            self.resourceinstanceid = ko.observable(params.report?.report_json?.resourceinstanceid);
 
             self.nameDataConfig = {
                 name: 'artefact',

--- a/arches_her/media/js/views/components/reports/bibliographic-source.js
+++ b/arches_her/media/js/views/components/reports/bibliographic-source.js
@@ -7,6 +7,7 @@ define([
     'utils/report',
     'templates/views/components/reports/bibliographic-source.htm',
     'views/components/reports/scenes/name',
+    'views/components/reports/scenes/referenced-by',
     'views/components/reports/scenes/audit',
     'views/components/reports/scenes/default',
     'views/components/reports/scenes/json',
@@ -33,6 +34,7 @@ define([
             self.resource = ko.observable(self.reportMetadata()?.resource);
             self.displayname = ko.observable(ko.unwrap(self.reportMetadata)?.displayname);
             self.activeSection = ko.observable('source');
+            self.resourceinstanceid = ko.observable(params.report?.report_json?.resourceinstanceid);
 
             self.publicationTableConfig = {
                 ...self.defaultTableConfig,

--- a/arches_her/media/js/views/components/reports/consultation.js
+++ b/arches_her/media/js/views/components/reports/consultation.js
@@ -7,6 +7,7 @@ define([
     'utils/report',
     'templates/views/components/reports/consultation.htm',
     'views/components/reports/scenes/name',
+    'views/components/reports/scenes/referenced-by',
     'views/components/reports/scenes/json',
     'bindings/reports'
 ], function($, _, ko, arches, resourceUtils, reportUtils, ConsultationTemplate) {
@@ -32,6 +33,7 @@ define([
             self.reportMetadata = ko.observable(params.report?.report_json);
             self.resource = ko.observable(self.reportMetadata()?.resource);
             self.displayname = ko.observable(ko.unwrap(self.reportMetadata)?.displayname);
+            self.resourceinstanceid = ko.observable(params.report?.report_json?.resourceinstanceid);
             self.activeSection = ko.observable('details');
 
             self.nameDataConfig = {

--- a/arches_her/media/js/views/components/reports/digital-object.js
+++ b/arches_her/media/js/views/components/reports/digital-object.js
@@ -7,6 +7,7 @@ define([
     'utils/report',
     'templates/views/components/reports/digital-object.htm',
     'views/components/reports/scenes/name',
+    'views/components/reports/scenes/referenced-by',
     'views/components/reports/scenes/copyright',
     'views/components/reports/scenes/json',
     'bindings/reports'
@@ -28,7 +29,8 @@ define([
             self.reportMetadata = ko.observable(params.report?.report_json);
             self.resource = ko.observable(self.reportMetadata()?.resource);
             self.displayname = ko.observable(ko.unwrap(self.reportMetadata)?.displayname);
-            self.activeSection = ko.observable('name');
+            self.activeSection = ko.observable('name');            
+            self.resourceinstanceid = ko.observable(params.report?.report_json?.resourceinstanceid);
 
             self.nameDataConfig = {};
 

--- a/arches_her/media/js/views/components/reports/heritage-story.js
+++ b/arches_her/media/js/views/components/reports/heritage-story.js
@@ -7,6 +7,7 @@ define([
     'utils/report',
     'templates/views/components/reports/heritage-story.htm',
     'views/components/reports/scenes/name',
+    'views/components/reports/scenes/referenced-by',
     'views/components/reports/scenes/json',
     'bindings/reports'
 ], function($, _, ko, arches, resourceUtils, reportUtils, HeritageStoryTemplate) {
@@ -29,6 +30,7 @@ define([
             self.resource = ko.observable(self.reportMetadata()?.resource);
             self.displayname = ko.observable(ko.unwrap(self.reportMetadata)?.displayname);
             self.activeSection = ko.observable('name');
+            self.resourceinstanceid = ko.observable(params.report?.report_json?.resourceinstanceid);
 
             self.nameDataConfig = {
                 parent: 'parent story'

--- a/arches_her/media/js/views/components/reports/historic-aircraft.js
+++ b/arches_her/media/js/views/components/reports/historic-aircraft.js
@@ -7,6 +7,7 @@ define([
     'utils/report',
     'templates/views/components/reports/historic-aircraft.htm',
     'views/components/reports/scenes/name',
+    'views/components/reports/scenes/referenced-by',
     'views/components/reports/scenes/json',
     'bindings/reports'
 ], function($, _, ko, arches, resourceUtils, reportUtils, HistoricAircraftTemplate) {
@@ -35,6 +36,7 @@ define([
             self.resource = ko.observable(self.reportMetadata()?.resource);
             self.displayname = ko.observable(ko.unwrap(self.reportMetadata)?.displayname);
             self.activeSection = ko.observable('name');
+            self.resourceinstanceid = ko.observable(params.report?.report_json?.resourceinstanceid);
             self.flights = ko.observableArray();
             self.lastFlight = ko.observableArray();
 

--- a/arches_her/media/js/views/components/reports/maritime-vessel.js
+++ b/arches_her/media/js/views/components/reports/maritime-vessel.js
@@ -7,6 +7,7 @@ define([
     'utils/report',
     'templates/views/components/reports/maritime-vessel.htm',
     'views/components/reports/scenes/name',
+    'views/components/reports/scenes/referenced-by',
     'views/components/reports/scenes/json',
     'bindings/reports'
 ], function($, _, ko, arches, resourceUtils, reportUtils, MaritimeVesselTemplate) {
@@ -52,6 +53,7 @@ define([
             self.resource = ko.observable(self.reportMetadata()?.resource);
             self.displayname = ko.observable(ko.unwrap(self.reportMetadata)?.displayname);
             self.activeSection = ko.observable('name');
+            self.resourceinstanceid = ko.observable(params.report?.report_json?.resourceinstanceid);
             self.nationalities = ko.observableArray();
             self.owners = ko.observableArray();
             self.voyages = ko.observableArray();

--- a/arches_her/media/js/views/components/reports/monument.js
+++ b/arches_her/media/js/views/components/reports/monument.js
@@ -7,6 +7,7 @@ define([
     'utils/report',
     'templates/views/components/reports/monument.htm',
     'views/components/reports/scenes/name',
+    'views/components/reports/scenes/referenced-by',
     'views/components/reports/scenes/json',
     'bindings/reports'
 ], function($, _, ko, arches, resourceUtils, reportUtils, MonumentTemplate) {
@@ -35,6 +36,8 @@ define([
             self.resource = ko.observable(self.reportMetadata()?.resource);
             self.displayname = ko.observable(ko.unwrap(self.reportMetadata)?.displayname);
             self.activeSection = ko.observable('name');
+
+            self.resourceinstanceid = ko.observable(params.report?.report_json?.resourceinstanceid);
 
             self.nameDataConfig = {
                 name: 'monument',

--- a/arches_her/media/js/views/components/reports/organization.js
+++ b/arches_her/media/js/views/components/reports/organization.js
@@ -7,6 +7,7 @@ define([
     'utils/report',
     'templates/views/components/reports/organization.htm',
     'views/components/reports/scenes/name',
+    'views/components/reports/scenes/referenced-by',
     'views/components/reports/scenes/contact',
     'views/components/reports/scenes/json',
     'bindings/reports'
@@ -33,6 +34,7 @@ define([
             self.resource = ko.observable(self.reportMetadata()?.resource);
             self.displayname = ko.observable(ko.unwrap(self.reportMetadata)?.displayname);
             self.activeSection = ko.observable('name');
+            self.resourceinstanceid = ko.observable(params.report?.report_json?.resourceinstanceid);
 
             self.nameDataConfig = {
                 name: 'names',

--- a/arches_her/media/js/views/components/reports/person.js
+++ b/arches_her/media/js/views/components/reports/person.js
@@ -7,6 +7,7 @@ define([
     'utils/report',
     'templates/views/components/reports/person.htm',
     'views/components/reports/scenes/name',
+    'views/components/reports/scenes/referenced-by',
     'bindings/reports'
 ], function($, _, ko, arches, resourceUtils, reportUtils, PersonTemplate) {
     return ko.components.register('person-report', {
@@ -32,6 +33,7 @@ define([
             self.resource = ko.observable(self.reportMetadata()?.resource);
             self.displayname = ko.observable(ko.unwrap(self.reportMetadata)?.displayname);
             self.activeSection = ko.observable('name');
+            self.resourceinstanceid = ko.observable(params.report?.report_json?.resourceinstanceid);
             self.names = ko.observableArray();
 
             self.contactPointsTable = {

--- a/arches_her/templates/views/components/reports/activity.htm
+++ b/arches_her/templates/views/components/reports/activity.htm
@@ -95,6 +95,13 @@
             </div>
             <!-- Associated Resources Tab -->
             <div id="tabcontent_resources" class="aher-report-page" data-bind="if: activeSection() === 'resources'" aria-live="polite" role="tabpanel">
+                <!-- Referenced By section -->
+                <div data-bind="component: {
+                    name: 'views/components/reports/scenes/referenced-by',
+                    params: {
+                        resourceInstanceId: ko.unwrap(resourceinstanceid),
+                    }
+                }"></div>
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/resources',
                     params: {

--- a/arches_her/templates/views/components/reports/area.htm
+++ b/arches_her/templates/views/components/reports/area.htm
@@ -115,9 +115,6 @@
             </div>
             <!-- Resources Tab -->
             <div id="tabcontent_resources" class="aher-report-page" data-bind="if: activeSection() === 'resources'" aria-live="polite" role="tabpanel">
-                <p class="sr-only" data-bind="let: {tabTitleText: document.querySelector('.aher-report-anchors li.active').innerText + ' tab now displayed'}">
-                    <span data-bind="text: {% trans "tabTitleText" %}"></span>
-                </p>
                 <!-- Referenced By section -->
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/referenced-by',

--- a/arches_her/templates/views/components/reports/area.htm
+++ b/arches_her/templates/views/components/reports/area.htm
@@ -115,6 +115,16 @@
             </div>
             <!-- Resources Tab -->
             <div id="tabcontent_resources" class="aher-report-page" data-bind="if: activeSection() === 'resources'" aria-live="polite" role="tabpanel">
+                <p class="sr-only" data-bind="let: {tabTitleText: document.querySelector('.aher-report-anchors li.active').innerText + ' tab now displayed'}">
+                    <span data-bind="text: {% trans "tabTitleText" %}"></span>
+                </p>
+                <!-- Referenced By section -->
+                <div data-bind="component: {
+                    name: 'views/components/reports/scenes/referenced-by',
+                    params: {
+                        resourceInstanceId: ko.unwrap(resourceinstanceid),
+                    }
+                }"></div>
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/resources',
                     params: {

--- a/arches_her/templates/views/components/reports/artefact.htm
+++ b/arches_her/templates/views/components/reports/artefact.htm
@@ -221,6 +221,13 @@
             </div>
             <!-- Resources Tab -->
             <div id="tabcontent_resources" class="aher-report-page" data-bind="if: activeSection() === 'resources'" aria-live="polite" role="tabpanel">
+                <!-- Referenced By section -->
+                <div data-bind="component: {
+                    name: 'views/components/reports/scenes/referenced-by',
+                    params: {
+                        resourceInstanceId: ko.unwrap(resourceinstanceid),
+                    }
+                }"></div>                
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/resources',
                     params: {

--- a/arches_her/templates/views/components/reports/bibliographic-source.htm
+++ b/arches_her/templates/views/components/reports/bibliographic-source.htm
@@ -239,6 +239,13 @@
             </div>
            <!-- Resources Tab -->
            <div id="tabcontent_resources" class="aher-report-page" data-bind="if: activeSection() === 'resources'" aria-live="polite" role="tabpanel">
+                <!-- Referenced By section -->
+                <div data-bind="component: {
+                    name: 'views/components/reports/scenes/referenced-by',
+                    params: {
+                        resourceInstanceId: ko.unwrap(resourceinstanceid),
+                    }
+                }"></div>
                 <div data-bind="component: {
                    name: 'views/components/reports/scenes/resources',
                    params: {

--- a/arches_her/templates/views/components/reports/consultation.htm
+++ b/arches_her/templates/views/components/reports/consultation.htm
@@ -803,6 +803,13 @@
             </div>
             <!-- Resources Tab -->
             <div id="tabcontent_resources" class="aher-report-page" data-bind="if: activeSection() === 'resources'" aria-live="polite" role="tabpanel">
+                <!-- Referenced By section -->
+                <div data-bind="component: {
+                    name: 'views/components/reports/scenes/referenced-by',
+                    params: {
+                        resourceInstanceId: ko.unwrap(resourceinstanceid),
+                    }
+                }"></div>
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/resources',
                     params: {

--- a/arches_her/templates/views/components/reports/digital-object.htm
+++ b/arches_her/templates/views/components/reports/digital-object.htm
@@ -39,6 +39,13 @@
                         dataConfig: nameDataConfig
                     }
                 }"></div>
+                <!-- Referenced By section -->
+                <div data-bind="component: {
+                    name: 'views/components/reports/scenes/referenced-by',
+                    params: {
+                        resourceInstanceId: ko.unwrap(resourceinstanceid),
+                    }
+                }"></div> 
             </div>
             <!-- Description Tab -->
             <div id="tabcontent_description" class="aher-report-page" data-bind="if: activeSection() === 'description'" aria-live="polite" role="tabpanel">

--- a/arches_her/templates/views/components/reports/heritage-story.htm
+++ b/arches_her/templates/views/components/reports/heritage-story.htm
@@ -64,6 +64,13 @@
             </div>
             <!-- Resources Tab -->
             <div id="tabcontent_resources" class="aher-report-page" data-bind="if: activeSection() === 'resources'" aria-live="polite" role="tabpanel">
+                <!-- Referenced By section -->
+                <div data-bind="component: {
+                    name: 'views/components/reports/scenes/referenced-by',
+                    params: {
+                        resourceInstanceId: ko.unwrap(resourceinstanceid),
+                    }
+                }"></div> 
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/resources',
                     params: {

--- a/arches_her/templates/views/components/reports/historic-aircraft.htm
+++ b/arches_her/templates/views/components/reports/historic-aircraft.htm
@@ -272,6 +272,13 @@
             </div>
             <!-- Resources Tab -->
             <div id="tabcontent_resources" class="aher-report-page" data-bind="if: activeSection() === 'resources'" aria-live="polite" role="tabpanel">
+                <!-- Referenced By section -->
+                <div data-bind="component: {
+                    name: 'views/components/reports/scenes/referenced-by',
+                    params: {
+                        resourceInstanceId: ko.unwrap(resourceinstanceid),
+                    }
+                }"></div> 
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/resources',
                     params: {

--- a/arches_her/templates/views/components/reports/maritime-vessel.htm
+++ b/arches_her/templates/views/components/reports/maritime-vessel.htm
@@ -310,6 +310,13 @@
             </div>
             <!-- Resources Tab -->
             <div id="tabcontent_resources" class="aher-report-page" data-bind="if: activeSection() === 'resources'" aria-live="polite" role="tabpanel">
+                <!-- Referenced By section -->
+                <div data-bind="component: {
+                    name: 'views/components/reports/scenes/referenced-by',
+                    params: {
+                        resourceInstanceId: ko.unwrap(resourceinstanceid),
+                    }
+                }"></div> 
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/resources',
                     params: {

--- a/arches_her/templates/views/components/reports/monument.htm
+++ b/arches_her/templates/views/components/reports/monument.htm
@@ -114,6 +114,17 @@
             </div>
             <!-- Resources Tab -->
             <div id="tabcontent_resources" class="aher-report-page" data-bind="if: activeSection() === 'resources'" aria-live="polite" role="tabpanel">
+                
+                
+                <!-- Referenced By section -->
+                <div data-bind="component: {
+                    name: 'views/components/reports/scenes/referenced-by',
+                    params: {
+                        resourceInstanceId: ko.unwrap(resourceinstanceid),
+                    }
+                }"></div>
+                
+                
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/resources',
                     params: {

--- a/arches_her/templates/views/components/reports/organization.htm
+++ b/arches_her/templates/views/components/reports/organization.htm
@@ -72,6 +72,13 @@
             </div>
             <!-- Resources Tab -->
             <div id="tabcontent_resources" class="aher-report-page" data-bind="if: activeSection() === 'resources'" aria-live="polite" role="tabpanel">
+                <!-- Referenced By section -->
+                <div data-bind="component: {
+                    name: 'views/components/reports/scenes/referenced-by',
+                    params: {
+                        resourceInstanceId: ko.unwrap(resourceinstanceid),
+                    }
+                }"></div> 
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/resources',
                     params: {

--- a/arches_her/templates/views/components/reports/person.htm
+++ b/arches_her/templates/views/components/reports/person.htm
@@ -114,6 +114,13 @@
             </div>
             <!-- Resources Tab -->
             <div id="tabcontent_resources" class="aher-report-page" data-bind="if: activeSection() === 'resources'" aria-live="polite" role="tabpanel">
+                <!-- Referenced By section -->
+                <div data-bind="component: {
+                    name: 'views/components/reports/scenes/referenced-by',
+                    params: {
+                        resourceInstanceId: ko.unwrap(resourceinstanceid),
+                    }
+                }"></div> 
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/resources',
                     params: {

--- a/releases/1.1.0.md
+++ b/releases/1.1.0.md
@@ -4,6 +4,8 @@ Arches for HERs 1.1.0 Release Notes
 ### Bug Fixes and Enhancements
 
 - Retain placeholder text formatting for HTML (rich-text) values in consultation letters [#1365](https://github.com/archesproject/arches-her/pull/1365)
+- Fixes Referenced-by scene showing all relationships instead of just those that target the current resource [#1436](https://github.com/archesproject/arches-her/pull/1436)
+- Adds Referenced-by scene to most reports [#1435](https://github.com/archesproject/arches-her/pull/1435)
 - Adds new HTML export report template for Artefact resources [#1427](https://github.com/archesproject/arches-her/pull/1427)
 
 ### Dependency changes:


### PR DESCRIPTION
Requires merge of #1436 

This pull request enhances the reporting functionality across multiple resource report components by introducing a new "Referenced By" section to the resources tab of each report. This section displays resources that reference the current resource, improving traceability and navigation between related entities.

**Enhancement of report resources tab:**

* Added the `views/components/reports/scenes/referenced-by` component as a dependency and rendered it in the resources tab for the following reports: activity, area, artefact, bibliographic-source, consultation, digital-object, heritage-story, historic-aircraft, maritime-vessel, monument, organization, and person. This provides visibility into which other resources reference the current resource.

Closes #1410