### PR TITLE
Fixes Referenced-by scene showing all relationships instead of just those that target the current resource

### DIFF
--- a/arches_her/media/js/views/components/reports/scenes/referenced-by.js
+++ b/arches_her/media/js/views/components/reports/scenes/referenced-by.js
@@ -20,6 +20,7 @@ function($, _, ko, arches, reportUtils, ReferencedByTemplate) {
             self.visible = {
                 referencedBy: ko.observable(true),
             };
+            self.loaderror = ko.observable(false);
 
             // referenced by table configuration
             self.referencedByTwoColumnTableConfig = {
@@ -43,12 +44,14 @@ function($, _, ko, arches, reportUtils, ReferencedByTemplate) {
                     }
                     return;
                 }).fail(function() {
-                    // error
+                    console.error("Unable to load graphs for referenced by scene");
+                    self.loaderror(true);
                 });
             };
 
 
-             self.getRelatedResources = function(){
+            self.getRelatedResources = function(){
+                self.loaderror(false);
                 return $.ajax({
                     url: arches.urls.related_resources + self.resourceinstanceid,
                     context: self,
@@ -83,7 +86,9 @@ function($, _, ko, arches, reportUtils, ReferencedByTemplate) {
                     });
                 })
                 .fail(function() {
-                    // error
+                    console.error("Unable to load related resources for referenced by scene");
+                    self.relations.removeAll();
+                    self.loaderror(true);
                 });
             };
 

--- a/arches_her/media/js/views/components/reports/scenes/referenced-by.js
+++ b/arches_her/media/js/views/components/reports/scenes/referenced-by.js
@@ -48,41 +48,45 @@ function($, _, ko, arches, reportUtils, ReferencedByTemplate) {
             };
 
 
-            self.getRelatedResources = function(){
+             self.getRelatedResources = function(){
                 return $.ajax({
                     url: arches.urls.related_resources + self.resourceinstanceid,
                     context: self,
                 })
-                    .done(function(response) {
-                        self.getGraphs().then(function(){
-                            let this_rid = response.related_resources.resource_instance.resourceinstanceid;
-                            //need to look at the resource_relationships and find other resources that are pointing TO this one
-                            other_resource_ids = [];
-                            for(const rr of response.related_resources.resource_relationships){
-                                if(rr.resourceinstanceidto == self.resourceinstanceid){
-                                    other_resource_ids.push(rr.resourceinstanceidfrom)
+                .done(function(response) {
+                    self.getGraphs().then(function(){
+                        const relationships = response.related_resources.resource_relationships;
+                        const relatedResources = response.related_resources.related_resources;
+                        // Collect resource IDs that point to this resource
+                        const otherResourceIds = relationships
+                            .filter(rr => rr.resourceinstanceidto === self.resourceinstanceid)
+                            .map(rr => rr.resourceinstanceidfrom);
+
+                        // Filter related resources that reference this one
+                        const filteredResources = relatedResources.filter(x => otherResourceIds.includes(x.resourceinstanceid));
+
+                        self.relations.removeAll();
+                        filteredResources.forEach(resource => {
+                            if (
+                                self.graphsList.length === 0 ||
+                                self.graphsList.includes(resource.graph_id)
+                            ) {
+                                const graphObj = self.graphs.find(gr => gr.graphid === resource.graph_id);
+                                const graphName = graphObj ? graphObj.name : "unknown";
+                                self.relations.push({
+                                    related_resource_name: resource.displayname,
+                                    related_resource_link: arches.urls.resource_report + resource.resourceinstanceid,
+                                    related_resource_type: graphName
+                                });
                             }
-                            }
-                            // we now have the resources that point at this one.
-                            var responseRelatedResources = response.related_resources.related_resources.filter((x) => other_resource_ids.includes(x.resourceinstanceid));
-                            self.relations.removeAll();
-                            for(let r in responseRelatedResources){
-                                var responseRelatedResource = responseRelatedResources[r];
-                                if(
-                                    self.graphsList.length === 0 || self.graphsList.includes(responseRelatedResource["graph_id"] )){
-                                    
-                                    var graphObj = self.graphs.find((gr) => gr.graphid === responseRelatedResource["graph_id"]);
-                                    var graphName = graphObj ? graphObj.name : "unknown";
-                                    self.relations.push({"related_resource_name": responseRelatedResource["displayname"], "related_resource_link": arches.urls.resource_report + responseRelatedResource["resourceinstanceid"], "related_resource_type": graphName});
-                                }
-                            }
-                            return;
                         });
-                    })
-                    .fail(function() {
-                        // error
                     });
+                })
+                .fail(function() {
+                    // error
+                });
             };
+
 
             self.getRelatedResources();
         },

--- a/arches_her/media/js/views/components/reports/scenes/referenced-by.js
+++ b/arches_her/media/js/views/components/reports/scenes/referenced-by.js
@@ -13,7 +13,7 @@ function($, _, ko, arches, reportUtils, ReferencedByTemplate) {
             const self = this;
             Object.assign(self, reportUtils);
             self.resourceinstanceid = params.resourceInstanceId;
-            self.graphsArray = params.graphs;
+            self.graphsArray = params.graphs || [];
             self.graphsList = [];
             self.graphs = [];
             self.relations = ko.observableArray();
@@ -55,12 +55,24 @@ function($, _, ko, arches, reportUtils, ReferencedByTemplate) {
                 })
                     .done(function(response) {
                         self.getGraphs().then(function(){
-                            var responseRelatedResources = response.related_resources.related_resources;
+                            let this_rid = response.related_resources.resource_instance.resourceinstanceid;
+                            //need to look at the resource_relationships and find other resources that are pointing TO this one
+                            other_resource_ids = [];
+                            for(const rr of response.related_resources.resource_relationships){
+                                if(rr.resourceinstanceidto == self.resourceinstanceid){
+                                    other_resource_ids.push(rr.resourceinstanceidfrom)
+                            }
+                            }
+                            // we now have the resources that point at this one.
+                            var responseRelatedResources = response.related_resources.related_resources.filter((x) => other_resource_ids.includes(x.resourceinstanceid));
                             self.relations.removeAll();
                             for(let r in responseRelatedResources){
                                 var responseRelatedResource = responseRelatedResources[r];
-                                if(self.graphsList.includes(responseRelatedResource["graph_id"] )){
-                                    var graphName = (self.graphs.find((gr) => gr.graphid === responseRelatedResource["graph_id"]))["name"];
+                                if(
+                                    self.graphsList.length === 0 || self.graphsList.includes(responseRelatedResource["graph_id"] )){
+                                    
+                                    var graphObj = self.graphs.find((gr) => gr.graphid === responseRelatedResource["graph_id"]);
+                                    var graphName = graphObj ? graphObj.name : "unknown";
                                     self.relations.push({"related_resource_name": responseRelatedResource["displayname"], "related_resource_link": arches.urls.resource_report + responseRelatedResource["resourceinstanceid"], "related_resource_type": graphName});
                                 }
                             }

--- a/arches_her/templates/views/components/reports/scenes/referenced-by.htm
+++ b/arches_her/templates/views/components/reports/scenes/referenced-by.htm
@@ -8,13 +8,14 @@
 <!-- Collapsible content -->
 <div data-bind="visible: visible.referencedBy" class="aher-report-collapsible-container pad-lft">
 
-    <!-- ko if: relations().length == 0 -->
+    <!-- ko ifnot: relations().length -->
     <div class="aher-nodata-note">{% trans "No resource referenced by for this resource" %}</div>
     <!-- /ko -->
 
-    <!-- ko if: relations().length > 0 -->
+    <!-- ko if: relations().length -->
     <div class="aher-report-subsection">
         <div class="firstchild-container">
+            <span class="aher-nodata-note">This section shows other resources that hold a relationship to this resource.</span>
             <div class="aher-table">
                 <table id="referenced-by-table" class="table table-striped" cellspacing="0" width="100%">
                     <thead>

--- a/arches_her/templates/views/components/reports/scenes/referenced-by.htm
+++ b/arches_her/templates/views/components/reports/scenes/referenced-by.htm
@@ -8,14 +8,18 @@
 <!-- Collapsible content -->
 <div data-bind="visible: visible.referencedBy" class="aher-report-collapsible-container pad-lft">
 
-    <!-- ko ifnot: relations().length -->
+    <!-- ko if: loaderror() -->
+    <div class="aher-nodata-note">{% trans "There was an error while loading the resources that reference this resource." %}</div>
+    <!-- /ko -->
+
+    <!-- ko if: !relations().length && !loaderror() -->
     <div class="aher-nodata-note">{% trans "No resource referenced by for this resource" %}</div>
     <!-- /ko -->
 
     <!-- ko if: relations().length -->
     <div class="aher-report-subsection">
         <div class="firstchild-container">
-            <span class="aher-nodata-note">This section shows other resources that hold a relationship to this resource.</span>
+            <span class="aher-nodata-note">{% trans "This section shows other resources that hold a relationship to this resource." %}</span>
             <div class="aher-table">
                 <table id="referenced-by-table" class="table table-striped" cellspacing="0" width="100%">
                     <thead>


### PR DESCRIPTION
This pull request fixes the "Referenced By" report section by refining how related resources are filtered and displayed. The changes ensure that only resources which actually reference the current resource are shown.

It also adds a help note that tells the user that the lists shows resources that hold a relationship to this resource.

**Filtering and display improvements:**

* Updated the logic in `referenced-by.js` to filter related resources so that only those which point to the current resource are shown in the "Referenced By" section, using the `resource_relationships` data.
* Ensured that `self.graphsArray` is always initialized as an array to prevent errors when `params.graphs` is undefined.

**User interface enhancements:**

* Improved the conditional rendering in `referenced-by.htm` to show a clearer "no data" message when there are no referencing resources, and added a descriptive note explaining the section's purpose when resources are present.

Closes #1411 