### PR TITLE
Adds contributing.md and PR template to support contributors

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -32,16 +32,17 @@ Closes #
 
 ### Arches-HER Specific Checklist
 
-- [ ] Model/graph changes are scoped and explained (if applicable) and are accompanyed by migrations to update existing data where needed.
-- [ ] Model/graph changes have been discussed with the community (please link to Arches Forum discussions or GitHub issues where relevant)
-- [ ] Migration/load implications are documented below (if model/graph/package changed)
+- [ ] Model/graph changes are for the ongoing benefit of HERs and not for a specific project/use case.
+- [ ] Model/graph changes are clearly labelled in the PR title and description, and unrelated code changes are excluded.
+- [ ] Model/graph changes have been discussed with the community (link Arches Forum discussions or GitHub issues where relevant).
+- [ ] Migration/load implications are documented below (if model/graph/package changed).
 - [ ] If I edited letter templates, I ran `python manage.py docx fix_style_runs --dest_dir docx`
 
 Model/graph/package upgrade/load notes (if applicable):
 
 <!-- If your PR includes changes to models, graphs, or packages, explain any upgrade or load implications here. -->
 
-<!-- Discussion likes to Arches Forum or GitHub issues (if applicable): -->
+<!-- Discussion links to Arches Forum or GitHub issues (if applicable): -->
 
 ### Accessibility Checklist
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,70 @@
+# Pull Request
+
+<!-- Provide a general summary of the Pull Request in the Title above -->
+
+## Types of changes
+
+<!-- Put an `x` in the boxes that apply -->
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+
+## Description of Change
+
+<!-- Include a brief description of this Pull Request and reasoning behind it. -->
+
+## Issues Solved
+
+<!-- If this Pull Request solves any issues, list them here. -->
+Closes #
+
+## Checklist
+
+<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->
+- I targeted one of these branches:
+  - [ ] `dev/1.1.x` (default): features and bugfixes for the current release line
+  - [ ] `dev/2.0.x` (next major): work intended for the next major release
+- [ ] I added/updated a release note in `releases/` (if appropriate)
+- [ ] I updated `README.md` (if setup/configuration/behaviour changed)
+- [ ] Unit tests pass locally with my changes
+- [ ] I added tests that prove my fix is effective or that my feature works
+- [ ] My test fails on the target branch (if claiming this, explain below)
+
+### Arches-HER Specific Checklist
+
+- [ ] Model/graph changes are scoped and explained (if applicable) and are accompanyed by migrations to update existing data where needed.
+- [ ] Model/graph changes have been discussed with the community (please link to Arches Forum discussions or GitHub issues where relevant)
+- [ ] Migration/load implications are documented below (if model/graph/package changed)
+- [ ] If I edited letter templates, I ran `python manage.py docx fix_style_runs --dest_dir docx`
+
+Model/graph/package upgrade/load notes (if applicable):
+
+<!-- If your PR includes changes to models, graphs, or packages, explain any upgrade or load implications here. -->
+
+<!-- Discussion likes to Arches Forum or GitHub issues (if applicable): -->
+
+### Accessibility Checklist
+
+<!-- If your changes impacted the following areas, mark the appropriate columns. -->
+
+| Topic             | Changed | Retested |
+| ----------------- | ------- | -------- |
+| Color contrast    |         |          |
+| Form fields       |         |          |
+| Headings          |         |          |
+| Links             |         |          |
+| Keyboard          |         |          |
+| Responsive design |         |          |
+| HTML validation   |         |          |
+| Screen reader     |         |          |
+
+## Ticket Background
+
+- Sponsored by: <!-- Who is funding this effort? -->
+- Found by: @ <!-- This could be the person who files the bug, but not always. -->
+- Tested by: @ <!-- Who tested this? -->
+- Designed by: @ <!-- Who designed this new feature? -->
+
+## Further comments
+
+<!-- If this is a relatively large or complex change, explain trade-offs, alternatives, or follow-up work. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-# Pull Request
+# Pull Request Template
 
 <!-- Provide a general summary of the Pull Request in the Title above -->
 
@@ -8,6 +8,7 @@
 - [ ] Bugfix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+  - [ ] Involves changes to the Model/Graph, Concepts or Collections, or ontologies.
 
 ## Description of Change
 
@@ -30,15 +31,16 @@ Closes #
 - [ ] I added tests that prove my fix is effective or that my feature works
 - [ ] My test fails on the target branch (if claiming this, explain below)
 
-### Arches-HER Specific Checklist
+## Arches-HER Specific Checklist
 
-- [ ] Model/graph changes are for the ongoing benefit of HERs and not for a specific project/use case.
-- [ ] Model/graph changes are clearly labelled in the PR title and description, and unrelated code changes are excluded.
-- [ ] Model/graph changes have been discussed with the community (link Arches Forum discussions or GitHub issues where relevant).
-- [ ] Migration/load implications are documented below (if model/graph/package changed).
-- [ ] If I edited letter templates, I ran `python manage.py docx fix_style_runs --dest_dir docx`
+- Model/graph, concept and collection, or ontology changes will be closely reviewed. If your PR includes changes to these, please ensure they:
+  - [ ] Are for the ongoing benefit of HERs and not for a specific project/use case.
+  - [ ] Are clearly labelled in the PR title and description, and unrelated code changes are excluded.
+  - [ ] Have been discussed with the community (link Arches Forum discussions or GitHub issues where relevant).
+- [ ] Migration/load implications are documented below (if model/graph/package, concept or collection changed).
+- [ ] If I edited letter templates, I ran `python manage.py docx fix_style_runs --dest_dir docx`.
 
-Model/graph/package upgrade/load notes (if applicable):
+**Model/graph/concept and collection/package upgrade/load notes (if applicable):**
 
 <!-- If your PR includes changes to models, graphs, or packages, explain any upgrade or load implications here. -->
 
@@ -46,7 +48,7 @@ Model/graph/package upgrade/load notes (if applicable):
 
 ### Accessibility Checklist
 
-<!-- If your changes impacted the following areas, mark the appropriate columns. -->
+<!-- If your changes impacted the UI, please ensure the following areas are checked and mark the appropriate columns. -->
 
 | Topic             | Changed | Retested |
 | ----------------- | ------- | -------- |

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -7,12 +7,11 @@ with Arches-HER specific requirements described below.
 - [Contributing to Arches-HER](#contributing-to-arches-her)
   - [Found an Issue?](#found-an-issue)
   - [Contributing Code](#contributing-code)
-    - [Important differences from core Arches](#important-differences-from-core-arches)
     - [Keeping your branch up to date](#keeping-your-branch-up-to-date)
   - [Shared Development Branches](#shared-development-branches)
   - [Commit Message Guidelines](#commit-message-guidelines)
   - [Arches-HER Specific Requirements](#arches-her-specific-requirements)
-    - [Model and package changes](#model-and-package-changes)
+    - [Model changes](#model-changes)
     - [Letter templates (DOCX)](#letter-templates-docx)
     - [Accessibility](#accessibility)
   - [Contributing Documentation](#contributing-documentation)
@@ -47,11 +46,6 @@ Please check existing open/closed issues first to avoid duplicates.
 5. Commit and push your branch.
 6. Open a pull request against `archesproject/arches-her`.
 
-### Important differences from core Arches
-
-- You **do not** need to sign a CLA for contributions to this repository.
-- Use `dev/1.1.x` as the default base branch for normal work unless maintainers request otherwise.
-
 ### Keeping your branch up to date
 
 If requested during review, rebase your branch against `dev/1.1.x` and force-push:
@@ -78,11 +72,14 @@ Contributors should normally branch from the current default branch unless a rev
 
 ## Arches-HER Specific Requirements
 
-### Model and package changes
+### Model changes
 
-- Prefer package-based changes under `arches_her/pkg/` (graphs, reference data, map layers, business data) rather than ad hoc runtime edits.
-- Treat graph/model changes as high-impact: keep them tightly scoped, explain migration/load implications in the PR, and include any required data/package update steps.
-- Avoid unrelated schema/model changes in the same PR.
+The models in Arches for HERs are shared application code, and changes to them can have wide-ranging impacts. They have been designed to meet the needs of a Historic Environment Record so alterations must be for the ongoing benefit of HERs and not for the needs of a specific project or use case. If you are proposing changes to the models, please:
+
+- Model changes will be reviewed with particular care to ensure they are necessary and appropriately scoped, and may require more discussion and iteration than other types of changes.
+- Explain the reasoning and benefits of the change in your PR description, and include any relevant discussions or references to Arches Forum or GitHub issues.
+- Include any necessary data migrations to update existing data to the new model, and explain the migration process and implications in your PR description.
+- PRs relating to model changes should not contain unrelated code changes, and should be clearly labelled as involving model changes in the PR title and description.
 
 ### Letter templates (DOCX)
 

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -74,12 +74,12 @@ Contributors should normally branch from the current default branch unless a rev
 
 ### Model changes
 
-The models in Arches for HERs are shared application code, and changes to them can have wide-ranging impacts. They have been designed to meet the needs of a Historic Environment Record so alterations must be for the ongoing benefit of HERs and not for the needs of a specific project or use case. If you are proposing changes to the models, please:
+The models and controlled vocabularies in Arches for HERs are shared application code, and changes to them can have wide-ranging impacts. They have been designed to meet the needs of a Historic Environment Record so alterations must be for the ongoing benefit of HERs and not for the needs of a specific project or use case. If you are proposing changes to the models, please:
 
-- Model changes will be reviewed with particular care to ensure they are necessary and appropriately scoped, and may require more discussion and iteration than other types of changes.
+- Model and controlled vocabulary (concepts and collections) changes will be reviewed with particular care to ensure they are necessary and appropriately scoped, and may require more discussion and iteration than other types of changes.
 - Explain the reasoning and benefits of the change in your PR description, and include any relevant discussions or references to Arches Forum or GitHub issues.
-- Include any necessary data migrations to update existing data to the new model, and explain the migration process and implications in your PR description.
-- PRs relating to model changes should not contain unrelated code changes, and should be clearly labelled as involving model changes in the PR title and description.
+- Include any necessary data migrations to update existing data to the new model/vocabularies, and explain the migration process and implications in your PR description.
+- PRs relating to model and controlled vocabulary changes should not contain unrelated code changes, and should be clearly labelled as involving model and controlled vocabulary changes in the PR title and description.
 
 ### Letter templates (DOCX)
 

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -1,0 +1,117 @@
+# Contributing to Arches-HER
+
+We welcome contributions to Arches-HER. This guide follows the same general approach as the
+[Arches contributing guide](https://github.com/archesproject/arches/blob/dev/8.1.x/CONTRIBUTING.md),
+with Arches-HER specific requirements described below.
+
+- [Contributing to Arches-HER](#contributing-to-arches-her)
+  - [Found an Issue?](#found-an-issue)
+  - [Contributing Code](#contributing-code)
+    - [Important differences from core Arches](#important-differences-from-core-arches)
+    - [Keeping your branch up to date](#keeping-your-branch-up-to-date)
+  - [Shared Development Branches](#shared-development-branches)
+  - [Commit Message Guidelines](#commit-message-guidelines)
+  - [Arches-HER Specific Requirements](#arches-her-specific-requirements)
+    - [Model and package changes](#model-and-package-changes)
+    - [Letter templates (DOCX)](#letter-templates-docx)
+    - [Accessibility](#accessibility)
+  - [Contributing Documentation](#contributing-documentation)
+
+## Found an Issue?
+
+If you find a bug, please open an issue in the `archesproject/arches-her` repository and include:
+
+- clear steps to reproduce
+- expected vs actual behaviour
+- screenshots/gifs where relevant
+- environment details (Arches version, browser, OS)
+
+Please check existing open/closed issues first to avoid duplicates.
+
+## Contributing Code
+
+1. Fork `archesproject/arches-her` and clone your fork.
+2. Create a feature branch from `dev/1.1.x`:
+
+   ```shell
+   git checkout -b 1231_short_description dev/1.1.x
+   ```
+
+3. Make focused changes for one issue/feature.
+4. Run relevant tests locally:
+
+   ```shell
+   python manage.py test tests --settings="tests.test_settings"
+   ```
+
+5. Commit and push your branch.
+6. Open a pull request against `archesproject/arches-her`.
+
+### Important differences from core Arches
+
+- You **do not** need to sign a CLA for contributions to this repository.
+- Use `dev/1.1.x` as the default base branch for normal work unless maintainers request otherwise.
+
+### Keeping your branch up to date
+
+If requested during review, rebase your branch against `dev/1.1.x` and force-push:
+
+```shell
+git rebase dev/1.1.x -i
+git push origin my-fix-branch -f
+```
+
+## Shared Development Branches
+
+Arches-HER follows long-lived `dev/A.B.x` branches for ongoing development, that allow future enhancements to be made to the next release (the default branch) while the current release is being stabilized. For example, `dev/1.1.x` is the current default and is receiving minor enhancments and fixes. The previous release branch, `dev/1.0.x`, would continue to receive critical bug fixes.
+
+When a new major version is being developed, a new `dev/2.0.x` branch will be created for that work, and `dev/1.1.x` will continue to receive bug fixes and minor improvements until the next major release.
+
+Contributors should normally branch from the current default branch unless a reviewer asks for a different target.
+
+## Commit Message Guidelines
+
+- Use present tense ("Add feature" not "Added feature").
+- Use imperative mood ("Fix bug" not "Fixes bug").
+- Keep the first line to 72 characters or fewer.
+- Reference the related issue where possible.
+
+## Arches-HER Specific Requirements
+
+### Model and package changes
+
+- Prefer package-based changes under `arches_her/pkg/` (graphs, reference data, map layers, business data) rather than ad hoc runtime edits.
+- Treat graph/model changes as high-impact: keep them tightly scoped, explain migration/load implications in the PR, and include any required data/package update steps.
+- Avoid unrelated schema/model changes in the same PR.
+
+### Letter templates (DOCX)
+
+Arches-HER letter templates can break when field tags are split across style runs. If you edit letter templates, run:
+
+```shell
+python manage.py docx fix_style_runs --dest_dir docx
+```
+
+The `--dest_dir` option is optional and defaults to `docx`.
+
+### Accessibility
+
+Arches-HER contributions must maintain WCAG 2.2 AA accessibility standards. In particular:
+
+- preserve keyboard accessibility and visible focus order
+- ensure sufficient contrast and readable content structure
+- provide meaningful labels/text alternatives for controls and media
+
+Include accessibility considerations in PR descriptions for UI changes.
+
+## Contributing Documentation
+
+Arches-HER currently has no separate documentation repository.
+
+For documentation updates:
+
+- update `README.md` as the primary developer/user-facing documentation
+- include any setup, configuration, and operational changes needed to run the application
+- where relevant, link to core Arches documentation for shared platform behaviour
+
+Thank you for contributing to Arches-HER.

--- a/releases/1.1.0.md
+++ b/releases/1.1.0.md
@@ -4,6 +4,7 @@ Arches for HERs 1.1.0 Release Notes
 ### Bug Fixes and Enhancements
 
 - Retain placeholder text formatting for HTML (rich-text) values in consultation letters [#1365](https://github.com/archesproject/arches-her/pull/1365)
+- Adds contribution guidelines and a template to help guide PR submissions [#1438](https://github.com/archesproject/arches-her/pull/1438)
 - Adds new HTML export report template for Artefact resources [#1427](https://github.com/archesproject/arches-her/pull/1427)
 
 ### Dependency changes:


### PR DESCRIPTION
Completes #1429 

This pull request adds contribution guidelines and a standardized pull request template to the repository. These were based upon the Arches equivalents (dev/8.1.x) that capture enhancements contributed by @kfogel in https://github.com/archesproject/arches/pull/12582

These changes will help maintain consistency, improve communication, and clarify requirements for contributors, especially around model changes, accessibility, and documentation.

**Contribution process improvements:**

* Added a comprehensive `CONTRIBUTING.MD` file that outlines how to report issues, contribute code, follow commit message guidelines, handle model/package changes, maintain accessibility standards, and update documentation. The guide also highlights differences from the core Arches project and provides step-by-step instructions for contributors.

**Pull request workflow enhancements:**

* Introduced a detailed `.github/pull_request_template.md` to standardize pull request submissions. The template includes sections for describing changes, linking issues, specifying branch targets, accessibility checks, and documenting model/package changes, ensuring all necessary information is provided during PR reviews.