### PR TITLE
Fixes Application Area MVT permissions Issue #1387

### DIFF
--- a/arches_her/views/map.py
+++ b/arches_her/views/map.py
@@ -15,16 +15,21 @@ class ApplicationAreas(View):
         try:
             node = models.Node.objects.get(nodeid=nodeid, nodegroup_id__in=viewable_nodegroups)
             se = SearchEngineFactory().create()
-            restricted_resource_ids = get_filtered_instances(request.user, search_engine=se)
-            if len(restricted_resource_ids) == 0:
-                restricted_resource_ids.append(
+            #restricted_resource_ids = get_filtered_instances(request.user, search_engine=se)
+            
+            # get_filtered_instances returns a list of ids and states whether they are exclusive (exclude the resourceids - from default deny)     
+            # or inclusive (only include these resourceids - from default allow).
+            is_exclusive, filtered_instances = get_filtered_instances(request.user, search_engine=se)
+
+            if len(filtered_instances) == 0:
+                filtered_instances.append(
                     "10000000-0000-0000-0000-000000000001"
-                )  # This must have a uuid that will never be a resource id.
-            restricted_resource_ids = tuple(restricted_resource_ids)
+                )  # This must have a uuid that will likely never be a resource id so to not break the SQL query when there are no resources to filter on.
+            filtered_instances = tuple(filtered_instances)
 
             with connection.cursor() as cursor:
                 result = cursor.execute(
-                    """SELECT ST_AsMVT(tile, 'app-area', 4096, 'geom', 'id') FROM (SELECT tileid,
+                    f"""SELECT ST_AsMVT(tile, 'app-area', 4096, 'geom', 'id') FROM (SELECT tileid,
                         id,
                         resourceinstanceid,
                         nodeid,
@@ -34,8 +39,8 @@ class ApplicationAreas(View):
                         ) AS geom,
                         1 AS total
                     FROM geojson_geometries
-                    WHERE nodeid = %s and resourceinstanceid not in %s and (geom && ST_TileEnvelope(%s, %s, %s))) AS tile;""",
-                    [zoom, x, y, nodeid, restricted_resource_ids, zoom, x, y],
+                    WHERE nodeid = %s and resourceinstanceid {'' if is_exclusive else 'not'} in %s and (geom && ST_TileEnvelope(%s, %s, %s))) AS tile;""",
+                    [zoom, x, y, nodeid, filtered_instances, zoom, x, y],
                 )
                 result = bytes(cursor.fetchone()[0]) if result is None else result
             return HttpResponse(result, content_type="application/x-protobuf")

--- a/arches_her/views/map.py
+++ b/arches_her/views/map.py
@@ -18,12 +18,12 @@ class ApplicationAreas(View):
 
             if node is None:
                 return HttpResponse(status=503)
-            
+
             candidate_resource_ids = [
                 str(resourceinstanceid)
-                for resourceinstanceid in models.ResourceInstance.objects.filter(
-                    graph_id=node.graph_id
-                ).values_list("resourceinstanceid", flat=True)
+                for resourceinstanceid in models.ResourceInstance.objects.filter(graph_id=node.graph_id).values_list(
+                    "resourceinstanceid", flat=True
+                )
             ]
 
             resource_filter_sql = ""
@@ -43,11 +43,7 @@ class ApplicationAreas(View):
 
                 if len(filtered_instances) > 0:
                     filtered_instances = tuple(filtered_instances)
-                    resource_filter_sql = (
-                        " and resourceinstanceid in %s"
-                        if is_exclusive
-                        else " and resourceinstanceid not in %s"
-                    )
+                    resource_filter_sql = " and resourceinstanceid in %s" if is_exclusive else " and resourceinstanceid not in %s"
                     resource_filter_params = [filtered_instances]
                 elif is_exclusive:
                     resource_filter_sql = " and 1=0"

--- a/arches_her/views/map.py
+++ b/arches_her/views/map.py
@@ -1,6 +1,6 @@
 from django.views.generic import View
 from django.db import connection
-from django.http import HttpResponse, Http404
+from django.http import HttpResponse
 from arches.app.models import models
 from arches.app.utils.permission_backend import get_filtered_instances
 from arches.app.search.search_engine_factory import SearchEngineFactory
@@ -16,15 +16,41 @@ class ApplicationAreas(View):
             node = models.Node.objects.get(nodeid=nodeid, nodegroup_id__in=viewable_nodegroups)
             se = SearchEngineFactory().create()
 
-            # get_filtered_instances returns a list of ids and states whether they are exclusive (exclude the resourceids - from default deny)
-            # or inclusive (only include these resourceids - from default allow).
-            is_exclusive, filtered_instances = get_filtered_instances(request.user, search_engine=se)
+            if node is None:
+                return HttpResponse(status=503)
+            
+            candidate_resource_ids = [
+                str(resourceinstanceid)
+                for resourceinstanceid in models.ResourceInstance.objects.filter(
+                    graph_id=node.graph_id
+                ).values_list("resourceinstanceid", flat=True)
+            ]
 
-            if len(filtered_instances) == 0:
-                filtered_instances.append(
-                    "10000000-0000-0000-0000-000000000001"
-                )  # This must have a uuid that will likely never be a resource id so to not break the SQL query when there are no resources to filter on.
-            filtered_instances = tuple(filtered_instances)
+            resource_filter_sql = ""
+            resource_filter_params = []
+
+            if len(candidate_resource_ids) == 0:
+                resource_filter_sql = " and 1=0"
+            else:
+                # get_filtered_instances returns ids plus framework mode:
+                # - is_exclusive=True (default deny): ids are an allow-list (include only these ids)
+                # - is_exclusive=False (default allow): ids are a deny-list (exclude these ids)
+                is_exclusive, filtered_instances = get_filtered_instances(
+                    request.user,
+                    search_engine=se,
+                    resources=candidate_resource_ids,
+                )
+
+                if len(filtered_instances) > 0:
+                    filtered_instances = tuple(filtered_instances)
+                    resource_filter_sql = (
+                        " and resourceinstanceid in %s"
+                        if is_exclusive
+                        else " and resourceinstanceid not in %s"
+                    )
+                    resource_filter_params = [filtered_instances]
+                elif is_exclusive:
+                    resource_filter_sql = " and 1=0"
 
             with connection.cursor() as cursor:
                 result = cursor.execute(
@@ -38,8 +64,8 @@ class ApplicationAreas(View):
                         ) AS geom,
                         1 AS total
                     FROM geojson_geometries
-                    WHERE nodeid = %s and resourceinstanceid {'' if is_exclusive else 'not'} in %s and (geom && ST_TileEnvelope(%s, %s, %s))) AS tile;""",
-                    [zoom, x, y, nodeid, filtered_instances, zoom, x, y],
+                    WHERE nodeid = %s{resource_filter_sql} and (geom && ST_TileEnvelope(%s, %s, %s))) AS tile;""",
+                    [zoom, x, y, nodeid, *resource_filter_params, zoom, x, y],
                 )
                 result = bytes(cursor.fetchone()[0]) if result is None else result
             return HttpResponse(result, content_type="application/x-protobuf")

--- a/arches_her/views/map.py
+++ b/arches_her/views/map.py
@@ -15,9 +15,8 @@ class ApplicationAreas(View):
         try:
             node = models.Node.objects.get(nodeid=nodeid, nodegroup_id__in=viewable_nodegroups)
             se = SearchEngineFactory().create()
-            #restricted_resource_ids = get_filtered_instances(request.user, search_engine=se)
-            
-            # get_filtered_instances returns a list of ids and states whether they are exclusive (exclude the resourceids - from default deny)     
+
+            # get_filtered_instances returns a list of ids and states whether they are exclusive (exclude the resourceids - from default deny)
             # or inclusive (only include these resourceids - from default allow).
             is_exclusive, filtered_instances = get_filtered_instances(request.user, search_engine=se)
 

--- a/releases/1.1.0.md
+++ b/releases/1.1.0.md
@@ -4,7 +4,7 @@ Arches for HERs 1.1.0 Release Notes
 ### Bug Fixes and Enhancements
 
 - Retain placeholder text formatting for HTML (rich-text) values in consultation letters [#1365](https://github.com/archesproject/arches-her/pull/1365)
-- Fixes Application Area MVT filtering to properly filter on both inclusive and exclusive resource instance lists [#999](https://github.com/archesproject/arches-her/pull/999)
+- Fixes Application Area MVT filtering to properly filter on both inclusive and exclusive resource instance lists [#1441](https://github.com/archesproject/arches-her/pull/1441)
 - Adds new HTML export report template for Artefact resources [#1427](https://github.com/archesproject/arches-her/pull/1427)
 
 ### Dependency changes:

--- a/releases/1.1.0.md
+++ b/releases/1.1.0.md
@@ -4,6 +4,7 @@ Arches for HERs 1.1.0 Release Notes
 ### Bug Fixes and Enhancements
 
 - Retain placeholder text formatting for HTML (rich-text) values in consultation letters [#1365](https://github.com/archesproject/arches-her/pull/1365)
+- Fixes Application Area MVT filtering to properly filter on both inclusive and exclusive resource instance lists [#999](https://github.com/archesproject/arches-her/pull/999)
 - Adds new HTML export report template for Artefact resources [#1427](https://github.com/archesproject/arches-her/pull/1427)
 
 ### Dependency changes:

--- a/tests/test_application_areas.py
+++ b/tests/test_application_areas.py
@@ -1,0 +1,209 @@
+import uuid
+from unittest.mock import patch
+from django.contrib.auth.models import User, Group
+from django.contrib.gis.geos import Point
+from django.test import TestCase, RequestFactory
+from guardian.shortcuts import assign_perm
+
+from arches.app.models.models import (
+    GeoJSONGeometry,
+    GraphModel,
+    Node,
+    NodeGroup,
+    ResourceInstance,
+    TileModel,
+    GraphXPublishedGraph,
+)
+from arches_her.views.map import ApplicationAreas
+
+# Run from the command line via:
+# python manage.py test tests.test_application_areas --settings="tests.test_settings"
+
+
+class ApplicationAreasPermissionTests(TestCase):
+    """
+    Tests that ApplicationAreas.get correctly enforces:
+      1. Nodegroup-level read permissions (user must be able to read the node's nodegroup)
+      2. Resource-instance-level permissions (default-allow deny-list / default-deny allow-list)
+    """
+
+    NODEID = "1909956f-3a3b-11eb-ae99-f875a44e0e11"
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.graph = GraphModel.objects.create(
+            graphid=uuid.uuid4(),
+            name="Test Application Area Graph",
+            isresource=True,
+        )
+        cls.publication = GraphXPublishedGraph.objects.create(
+            graph=cls.graph,
+        )
+        cls.graph.publication = cls.publication
+        cls.graph.save()
+
+        cls.nodegroup = NodeGroup.objects.create(
+            nodegroupid=uuid.uuid4(),
+            cardinality="n",
+        )
+        cls.node = Node.objects.create(
+            nodeid=cls.NODEID,
+            name="Application Area Geometry",
+            istopnode=True,
+            datatype="geojson-feature-collection",
+            nodegroup=cls.nodegroup,
+            graph=cls.graph,
+        )
+
+        cls.resource_ids = []
+        cls.tiles = []
+        cls.geometries = []
+
+        # A point in central London for test geometries
+        test_point = Point(-14000, 6711000, srid=3857)
+
+        for i in range(3):
+            rid = uuid.uuid4()
+            resource = ResourceInstance.objects.create(
+                resourceinstanceid=rid,
+                graph=cls.graph,
+                graph_publication=cls.publication,
+            )
+            cls.resource_ids.append(str(rid))
+
+            tile = TileModel.objects.create(
+                tileid=uuid.uuid4(),
+                resourceinstance=resource,
+                nodegroup=cls.nodegroup,
+                data={cls.NODEID: None},
+            )
+            cls.tiles.append(tile)
+
+            geom = GeoJSONGeometry.objects.create(
+                tile=tile,
+                resourceinstance=resource,
+                node=cls.node,
+                geom=test_point,
+            )
+            cls.geometries.append(geom)
+
+        cls.superuser = User.objects.create_superuser(
+            username="test_super",
+            email="super@test.com",
+            password="Test12345!",
+        )
+
+        cls.regular_user = User.objects.create_user(
+            username="test_regular",
+            email="regular@test.com",
+            password="Test12345!",
+        )
+        # Add to Resource Editor so permission framework treats them as a real user
+        editor_group, _ = Group.objects.get_or_create(name="Resource Editor")
+        cls.regular_user.groups.add(editor_group)
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.view = ApplicationAreas.as_view()
+        # Tile coords that cover a large area
+        self.zoom = 0
+        self.x = 0
+        self.y = 0
+
+    def _make_request(self, user):
+        request = self.factory.get(f"/application-areas/{self.zoom}/{self.x}/{self.y}.pbf")
+        request.user = user
+        return request
+
+    def _patch_get_filtered_instances(self, is_exclusive, filtered_ids):
+        """
+        Patches get_filtered_instances in the view module to return
+        a controlled (is_exclusive, filtered_ids) tuple.
+        """
+        return patch(
+            "arches_her.views.map.get_filtered_instances",
+            return_value=(is_exclusive, filtered_ids),
+        )
+
+    def test_superuser_gets_200(self):
+        """Superuser should always get a 200 response with tile data."""
+        with self._patch_get_filtered_instances(False, []):
+            request = self._make_request(self.superuser)
+            response = self.view(request, self.zoom, self.x, self.y)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/x-protobuf")
+
+    def test_default_allow_no_restrictions(self):
+        """
+        Default-allow with no restricted instances: user should get 200,
+        meaning all resources are visible.
+        """
+        with self._patch_get_filtered_instances(False, []):
+            request = self._make_request(self.regular_user)
+            response = self.view(request, self.zoom, self.x, self.y)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/x-protobuf")
+
+    def test_default_allow_with_restrictions(self):
+        """
+        Default-allow with one restricted resource: user should still
+        get 200, but the query should exclude the restricted resource.
+        """
+        restricted_id = self.resource_ids[0]
+        with self._patch_get_filtered_instances(False, [restricted_id]):
+            request = self._make_request(self.regular_user)
+            response = self.view(request, self.zoom, self.x, self.y)
+        self.assertEqual(response.status_code, 200)
+
+    def test_default_deny_with_allowed_instances(self):
+        """
+        Default-deny with some allowed instances: user should get 200.
+        Only the allowed resources should be included.
+        """
+        allowed_ids = [self.resource_ids[0], self.resource_ids[1]]
+        with self._patch_get_filtered_instances(True, allowed_ids):
+            request = self._make_request(self.regular_user)
+            response = self.view(request, self.zoom, self.x, self.y)
+        self.assertEqual(response.status_code, 200)
+
+    def test_default_deny_empty_allowed_returns_empty_tile(self):
+        """
+        Default-deny with NO allowed instances: should return 200 with
+        an empty MVT (the AND 1=0 clause ensures no rows).
+        """
+        with self._patch_get_filtered_instances(True, []):
+            request = self._make_request(self.regular_user)
+            response = self.view(request, self.zoom, self.x, self.y)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/x-protobuf")
+
+    def test_user_without_nodegroup_access_gets_503(self):
+        """
+        A user explicitly denied access to the node's nodegroup should
+        receive a 503 (Node.DoesNotExist because the nodegroup is excluded
+        from viewable_nodegroups).
+        """
+        no_access_user = User.objects.create_user(
+            username="test_no_access",
+            email="noaccess@test.com",
+            password="Test12345!",
+        )
+
+        assign_perm("no_access_to_nodegroup", no_access_user, self.nodegroup)
+        request = self._make_request(no_access_user)
+        response = self.view(request, self.zoom, self.x, self.y)
+        self.assertEqual(response.status_code, 503)
+
+    def test_no_resources_for_graph_returns_empty_tile(self):
+        """
+        If no ResourceInstance rows exist for the node's graph, the view
+        should short-circuit with AND 1=0 and return an empty tile.
+        """
+
+        ResourceInstance.objects.filter(graph=self.graph).delete()
+
+        request = self._make_request(self.regular_user)
+        response = self.view(request, self.zoom, self.x, self.y)
+        self.assertEqual(response.status_code, 200)

--- a/tests/test_application_areas.py
+++ b/tests/test_application_areas.py
@@ -133,8 +133,8 @@ class ApplicationAreasPermissionTests(TestCase):
         Extract all UUIDs from protobuf response body.
         """
         # UUID pattern: 8-4-4-4-12 hexadecimal characters separated by hyphens
-        uuid_pattern = rb'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
-        return [s.decode('ascii') for s in re.findall(uuid_pattern, response.content)]
+        uuid_pattern = rb"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+        return [s.decode("ascii") for s in re.findall(uuid_pattern, response.content)]
 
     def _assert_resources_in_response(self, response, expected_ids):
         """

--- a/tests/test_application_areas.py
+++ b/tests/test_application_areas.py
@@ -1,3 +1,4 @@
+import re
 import uuid
 from unittest.mock import patch
 from django.contrib.auth.models import User, Group
@@ -127,6 +128,30 @@ class ApplicationAreasPermissionTests(TestCase):
             return_value=(is_exclusive, filtered_ids),
         )
 
+    def _extract_strings_from_response(self, response):
+        """
+        Extract all UUIDs from protobuf response body.
+        """
+        # UUID pattern: 8-4-4-4-12 hexadecimal characters separated by hyphens
+        uuid_pattern = rb'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+        return [s.decode('ascii') for s in re.findall(uuid_pattern, response.content)]
+
+    def _assert_resources_in_response(self, response, expected_ids):
+        """
+        Assert that all expected resource IDs are present in the response.
+        """
+        response_strings = self._extract_strings_from_response(response)
+        for resource_id in expected_ids:
+            self.assertIn(resource_id, response_strings)
+
+    def _assert_resources_not_in_response(self, response, unexpected_ids):
+        """
+        Assert that all unexpected resource IDs are absent from the response.
+        """
+        response_strings = self._extract_strings_from_response(response)
+        for resource_id in unexpected_ids:
+            self.assertNotIn(resource_id, response_strings)
+
     def test_superuser_gets_200(self):
         """Superuser should always get a 200 response with tile data."""
         with self._patch_get_filtered_instances(False, []):
@@ -134,6 +159,8 @@ class ApplicationAreasPermissionTests(TestCase):
             response = self.view(request, self.zoom, self.x, self.y)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["Content-Type"], "application/x-protobuf")
+        # All resource IDs should be present in the response
+        self._assert_resources_in_response(response, self.resource_ids)
 
     def test_default_allow_no_restrictions(self):
         """
@@ -145,6 +172,8 @@ class ApplicationAreasPermissionTests(TestCase):
             response = self.view(request, self.zoom, self.x, self.y)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["Content-Type"], "application/x-protobuf")
+        # All resource IDs should be present
+        self._assert_resources_in_response(response, self.resource_ids)
 
     def test_default_allow_with_restrictions(self):
         """
@@ -156,6 +185,9 @@ class ApplicationAreasPermissionTests(TestCase):
             request = self._make_request(self.regular_user)
             response = self.view(request, self.zoom, self.x, self.y)
         self.assertEqual(response.status_code, 200)
+        # Restricted resource should NOT be in response, others should be
+        self._assert_resources_not_in_response(response, [restricted_id])
+        self._assert_resources_in_response(response, self.resource_ids[1:])
 
     def test_default_deny_with_allowed_instances(self):
         """
@@ -167,6 +199,9 @@ class ApplicationAreasPermissionTests(TestCase):
             request = self._make_request(self.regular_user)
             response = self.view(request, self.zoom, self.x, self.y)
         self.assertEqual(response.status_code, 200)
+        # Only allowed resources should be in response
+        self._assert_resources_in_response(response, allowed_ids)
+        self._assert_resources_not_in_response(response, [self.resource_ids[2]])
 
     def test_default_deny_empty_allowed_returns_empty_tile(self):
         """
@@ -178,6 +213,8 @@ class ApplicationAreasPermissionTests(TestCase):
             response = self.view(request, self.zoom, self.x, self.y)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["Content-Type"], "application/x-protobuf")
+        # No resource IDs should be in response
+        self._assert_resources_not_in_response(response, self.resource_ids)
 
     def test_user_without_nodegroup_access_gets_503(self):
         """
@@ -207,3 +244,5 @@ class ApplicationAreasPermissionTests(TestCase):
         request = self._make_request(self.regular_user)
         response = self.view(request, self.zoom, self.x, self.y)
         self.assertEqual(response.status_code, 200)
+        # No resource IDs should be in response
+        self._assert_resources_not_in_response(response, self.resource_ids)


### PR DESCRIPTION
This pull request updates the Application Area MVT (Mapbox Vector Tile) filtering logic to correctly handle both inclusive and exclusive resource instance lists, improving how map data is filtered based on user permissions. It also documents this fix in the release notes.

Improvements to MVT filtering logic:

* Updated the `get` method in `arches_her/views/map.py` to distinguish between exclusive and inclusive filtering modes using the return value from `get_filtered_instances`, ensuring the SQL query applies the correct inclusion or exclusion logic for resource instance IDs. [[1]](diffhunk://#diff-d3f53ca920820902c723c0abe3e7f87d297da0f2f48a3ee11fd737b7db94b862L18-R32) [[2]](diffhunk://#diff-d3f53ca920820902c723c0abe3e7f87d297da0f2f48a3ee11fd737b7db94b862L37-R43)

Documentation:

* Added a release note entry describing the fix for Application Area MVT filtering in `releases/1.1.0.md`.