### PR TITLE
Adds migration for workflow config, help button and starting help templates

### DIFF
--- a/arches_her/media/css/consultations.scss
+++ b/arches_her/media/css/consultations.scss
@@ -691,3 +691,9 @@ div.active-cons-hover-loading {
     justify-content: flex-end;
     border-bottom: 1px solid #ddd;
 }
+
+.workflow-link {
+    text-decoration: underline;
+    color: #0066cc; /* Ensures 4.5:1 contrast ratio */
+}
+

--- a/arches_her/media/js/views/components/plugins/init-workflow.js
+++ b/arches_her/media/js/views/components/plugins/init-workflow.js
@@ -9,11 +9,31 @@ define([
         this.workflows = ko.observableArray([]);
         this.helpTemplateData = ko.observableArray([]);
 
-        // retaining previous logic while all workflow config is stored in init-workflow
-        this.workflows = params.workflows.map(function(wf){
-            wf.url = arches.urls.plugin(wf.slug);
-            return wf;
-        }, this);
+        fetch(arches.urls.api_plugins).then(resp => {
+            if (resp.ok) {
+                return resp.json();
+            }
+            else {
+                params.alert(new JsonErrorAlertViewModel('ep-alert-red', resp.responseJSON));
+            }
+        }).then(respJSON => {
+            let workflows = respJSON.reduce((acc, plugin) => {
+                if (plugin.config.is_workflow) {
+                    plugin.url = arches.urls.plugin(plugin.slug);
+                    acc.push(plugin);
+                }
+                return acc;
+            }, []);
+
+            this.workflows(workflows);
+            this.helpTemplateData(workflows.reduce((acc, workflow) => {
+                if (workflow.helptemplate) {
+                    acc.push({'text': workflow.name, 'id': workflow.helptemplate});
+                }
+
+                return acc;
+            }, []));
+        });
 
         this.shouldShowWorkflowHelp = ko.observable(false);
         this.helpTemplateUrl = ko.observable();

--- a/arches_her/media/js/views/components/plugins/init-workflow.js
+++ b/arches_her/media/js/views/components/plugins/init-workflow.js
@@ -25,6 +25,17 @@ define([
                 return acc;
             }, []);
 
+            let workflowOrder = [
+                'b2778828-a6ac-6481-c38b-fd463d878f1f', // application area
+                'a1667717-b7bd-4570-b27a-ec352c767e0e', // consultation
+                '4dc9bd5a-6e5c-440d-ae3c-af94396e2d72', // communication
+                '0b1499e0-6cdc-403b-a2e3-499c2201069d', // site visit
+                '4bd762cf-b581-11e9-a7f9-784f435179ea', // correspondence
+            ]
+            workflows.sort((a, b) => {
+                return workflowOrder.indexOf(a.pluginid) - workflowOrder.indexOf(b.pluginid);
+            });
+
             this.workflows(workflows);
             this.helpTemplateData(workflows.reduce((acc, workflow) => {
                 if (workflow.helptemplate) {

--- a/arches_her/media/js/views/components/plugins/init-workflow.js
+++ b/arches_her/media/js/views/components/plugins/init-workflow.js
@@ -47,16 +47,21 @@ define([
         });
 
         this.shouldShowWorkflowHelp = ko.observable(false);
-        this.helpTemplateUrl = ko.observable();
+        this.helpTemplateHtml = ko.observable();
         this.isHelpTemplateLoading = ko.observable();
         this.selectedHelpTemplate = ko.observable();
         this.selectedHelpTemplate.subscribe(helpTemplateName => {
             if (helpTemplateName) {
                 this.isHelpTemplateLoading(true);
-                this.helpTemplateUrl(arches.urls.help_template + `?template=${helpTemplateName}`);
+                fetch(arches.urls.help_template + `?template=${helpTemplateName}`)
+                    .then(resp => resp.text())
+                    .then(html => {
+                        this.helpTemplateHtml(html);
+                        this.isHelpTemplateLoading(false);
+                    });
             }
             else {
-                this.helpTemplateUrl(null);
+                this.helpTemplateHtml(null);
             }
         })
 

--- a/arches_her/media/js/views/components/plugins/init-workflow.js
+++ b/arches_her/media/js/views/components/plugins/init-workflow.js
@@ -68,6 +68,19 @@ define([
         this.shouldShowIncompleteWorkflowsModal = ko.observable(false);
         this.requestingUserIsSuperuser = ko.observable(false);
 
+        // Subscribe to modal state to manage focus with delay for screen readers
+        this.shouldShowIncompleteWorkflowsModal.subscribe(isOpen => {
+            if (isOpen) {
+                // Delay focus to allow screen readers to announce dialog context
+                setTimeout(() => {
+                    const closeButton = document.getElementById('close-workflow-modal-btn');
+                    if (closeButton) {
+                        closeButton.focus();
+                    }
+                }, 100);
+            }
+        });
+
         this.incompleteWorkflows = ko.observableArray([]);
         this.incompleteWorkflows.subscribe(incompleteWorkflows => {
             if (incompleteWorkflows.length) {
@@ -92,6 +105,51 @@ define([
 
             this.requestingUserIsSuperuser(respJSON['requesting_user_is_superuser']);
        });
+
+        // Focus trap for incomplete workflows modal
+        this.handleModalKeydown = function(data, event) {
+            if (event.key === 'Tab' || event.keyCode === 9) {
+                const modal = event.currentTarget.querySelector('.workflow-incomplete-modal-container');
+                if (!modal) return true;
+
+                const focusableElements = modal.querySelectorAll(
+                    'button:not([disabled]), a[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+                );
+                
+                if (focusableElements.length === 0) return true;
+
+                const firstElement = focusableElements[0];
+                const lastElement = focusableElements[focusableElements.length - 1];
+
+                if (event.shiftKey) {
+                    // Shift + Tab: if on first element, move to last
+                    if (document.activeElement === firstElement) {
+                        lastElement.focus();
+                        event.preventDefault();
+                        return false;
+                    }
+                } else {
+                    // Tab: if on last element, move to first
+                    if (document.activeElement === lastElement) {
+                        firstElement.focus();
+                        event.preventDefault();
+                        return false;
+                    }
+                }
+            }
+            
+            // Allow Escape key to close modal
+            if (event.key === 'Escape' || event.keyCode === 27) {
+                this.shouldShowIncompleteWorkflowsModal(false);
+                setTimeout(() => {
+                    document.getElementById('show-workflow-modal-btn')?.focus();
+                }, 0);
+                event.preventDefault();
+                return false;
+            }
+
+            return true;
+        };
     };
 
     return ko.components.register('init-workflow', {

--- a/arches_her/migrations/0004_update_plugins.py
+++ b/arches_her/migrations/0004_update_plugins.py
@@ -49,6 +49,14 @@ class Migration(migrations.Migration):
         init_workflow_plugin.config["workflows"] = []
         init_workflow_plugin.save()
 
+    plugins = {
+        "application_area": {"id": "b2778828-a6ac-6481-c38b-fd463d878f1f", "help": "application-area-workflow-help"},
+        "communication": {"id": "4dc9bd5a-6e5c-440d-ae3c-af94396e2d72", "help": "communication-workflow-help"},
+        "consultation": {"id": "a1667717-b7bd-4570-b27a-ec352c767e0e", "help": "consultation-workflow-help"},
+        "correspondence": {"id": "4bd762cf-b581-11e9-a7f9-784f435179ea", "help": "correspondence-workflow-help"},
+        "site_visit": {"id": "0b1499e0-6cdc-403b-a2e3-499c2201069d", "help": "site-visit-workflow-help"},
+    }
+
     def revert_workflow_config(apps, schema_editor):
         Plugin = apps.get_model("models", "Plugin")
         init_workflow_plugin = Plugin.objects.get(pluginid="49507fb0-89c6-47b7-b506-9b2b29a3b8d8")
@@ -107,71 +115,24 @@ class Migration(migrations.Migration):
         # Revert config for each workflow plugin
         workflow_existing_config = {"show": False, "description": {"en": None}, "i18n_properties": ["description"]}
 
-        application_area = Plugin.objects.get(pluginid="b2778828-a6ac-6481-c38b-fd463d878f1f")
-        application_area.config = workflow_existing_config
-        application_area.save()
-
-        communication = Plugin.objects.get(pluginid="4dc9bd5a-6e5c-440d-ae3c-af94396e2d72")
-        communication.config = workflow_existing_config
-        communication.save()
-
-        consultation = Plugin.objects.get(pluginid="a1667717-b7bd-4570-b27a-ec352c767e0e")
-        consultation.config = workflow_existing_config
-        consultation.save()
-
-        correspondence = Plugin.objects.get(pluginid="4bd762cf-b581-11e9-a7f9-784f435179ea")
-        correspondence.config = workflow_existing_config
-        correspondence.save()
-
-        site_visit = Plugin.objects.get(pluginid="0b1499e0-6cdc-403b-a2e3-499c2201069d")
-        site_visit.config = workflow_existing_config
-        site_visit.save()
+        for plugin_details in Migration.plugins.values():
+            plugin = Plugin.objects.get(pk=plugin_details["id"])
+            plugin.config = workflow_existing_config
+            plugin.save()
 
     def add_workflow_help_templates(apps, schema_editor):
         Plugin = apps.get_model("models", "Plugin")
-
-        application_area = Plugin.objects.get(pluginid="b2778828-a6ac-6481-c38b-fd463d878f1f")
-        application_area.helptemplate = "application-area-workflow-help"
-        application_area.save()
-
-        communication = Plugin.objects.get(pluginid="4dc9bd5a-6e5c-440d-ae3c-af94396e2d72")
-        communication.helptemplate = "communication-workflow-help"
-        communication.save()
-
-        consultation = Plugin.objects.get(pluginid="a1667717-b7bd-4570-b27a-ec352c767e0e")
-        consultation.helptemplate = "consultation-workflow-help"
-        consultation.save()
-
-        correspondence = Plugin.objects.get(pluginid="4bd762cf-b581-11e9-a7f9-784f435179ea")
-        correspondence.helptemplate = "correspondence-workflow-help"
-        correspondence.save()
-
-        site_visit = Plugin.objects.get(pluginid="0b1499e0-6cdc-403b-a2e3-499c2201069d")
-        site_visit.helptemplate = "site-visit-workflow-help"
-        site_visit.save()
+        for plugin_details in Migration.plugins.values():
+            plugin = Plugin.objects.get(pk=plugin_details["id"])
+            plugin.helptemplate = plugin_details["help"]
+            plugin.save()
 
     def remove_workflow_help_templates(apps, schema_editor):
         Plugin = apps.get_model("models", "Plugin")
-
-        application_area = Plugin.objects.get(pluginid="b2778828-a6ac-6481-c38b-fd463d878f1f")
-        application_area.helptemplate = None
-        application_area.save()
-
-        communication = Plugin.objects.get(pluginid="4dc9bd5a-6e5c-440d-ae3c-af94396e2d72")
-        communication.helptemplate = None
-        communication.save()
-
-        consultation = Plugin.objects.get(pluginid="a1667717-b7bd-4570-b27a-ec352c767e0e")
-        consultation.helptemplate = None
-        consultation.save()
-
-        correspondence = Plugin.objects.get(pluginid="4bd762cf-b581-11e9-a7f9-784f435179ea")
-        correspondence.helptemplate = None
-        correspondence.save()
-
-        site_visit = Plugin.objects.get(pluginid="0b1499e0-6cdc-403b-a2e3-499c2201069d")
-        site_visit.helptemplate = None
-        site_visit.save()
+        for plugin_details in Migration.plugins.values():
+            plugin = Plugin.objects.get(pk=plugin_details["id"])
+            plugin.helptemplate = None
+            plugin.save()
 
     operations = [
         migrations.RunSQL(add_plugin_show_true_accessibility_activecons, remove_plugin_show_accessibility_activecons),

--- a/arches_her/migrations/0004_update_plugins.py
+++ b/arches_her/migrations/0004_update_plugins.py
@@ -21,7 +21,153 @@ class Migration(migrations.Migration):
         WHERE pluginid in ('%s','%s');
         """ % (active_consultations, accessibility_plugin)
 
+    def workflow_config_update(apps, scheme_editor):
+        Plugin = apps.get_model("models", "Plugin")
+
+        init_workflow_plugin = Plugin.objects.get(pluginid="49507fb0-89c6-47b7-b506-9b2b29a3b8d8")
+
+        # All plugin config exists within init-workflow, here we extract it and apply to the respective plugin
+        for wf_config in init_workflow_plugin.config["workflows"]:
+            inner_worfklow_plugin = Plugin.objects.get(pluginid=wf_config["workflowid"])
+
+            inner_worfklow_plugin.config = {"show": False,
+                                            "is_workflow": True,
+                                            "description": wf_config["desc"],
+                                            "thumbnailBackgroundColor": wf_config["bgColor"],
+                                            "thumbnailCircleColor": wf_config["circleColor"],
+                                            }
+            inner_worfklow_plugin.save()
+
+        # clear list from init-workflow (del list produces error)
+        init_workflow_plugin.config["workflows"] = []
+        init_workflow_plugin.save()
+
+    def revert_workflow_config(apps, schema_editor):
+        Plugin = apps.get_model("models", "Plugin")
+        init_workflow_plugin = Plugin.objects.get(pluginid="49507fb0-89c6-47b7-b506-9b2b29a3b8d8")
+
+        # Revert the workflows list in the init-workflow plugin
+        workflows_config_list = [
+            {
+                "desc": "An area that may be re-developed or newly built",
+                "icon": "fa fa-building",
+                "name": "Application Area",
+                "slug": "application-area",
+                "bgColor": "#87bceb",
+                "workflowid": "b2778828-a6ac-6481-c38b-fd463d878f1f",
+                "circleColor": "#a7cdf0",
+            },
+            {
+                "desc": "Advice on the potential work related to an application area",
+                "icon": "fa fa-file",
+                "name": "Consultation",
+                "slug": "consultation-workflow",
+                "bgColor": "#62a3db",
+                "workflowid": "a1667717-b7bd-4570-b27a-ec352c767e0e",
+                "circleColor": "#8bbfea",
+            },
+            {
+                "desc": "A conversation via phone, email, or other channel",
+                "icon": "fa fa-comment",
+                "name": "Communication",
+                "slug": "communication-workflow",
+                "bgColor": "#9795EE",
+                "workflowid": "4dc9bd5a-6e5c-440d-ae3c-af94396e2d72",
+                "circleColor": "#8bbbe4",
+            },
+            {
+                "desc": "A visit to ensure that a condition has been met",
+                "icon": "fa fa-clipboard",
+                "name": "Site Visit",
+                "slug": "site-visit",
+                "bgColor": "#716FE0",
+                "workflowid": "0b1499e0-6cdc-403b-a2e3-499c2201069d",
+                "circleColor": "#b0aff0",
+            },
+            {
+                "desc": "Letter or other document sent to an applicant",
+                "icon": "fa fa-envelope",
+                "name": "Correspondence",
+                "slug": "correspondence-workflow",
+                "bgColor": "#fed04f",
+                "workflowid": "4bd762cf-b581-11e9-a7f9-784f435179ea",
+                "circleColor": "#fedc7d",
+            },
+        ]
+        init_workflow_plugin.config["workflows"] = workflows_config_list
+
+        # Revert config for each workflow plugin
+        workflow_existing_config = {"show": False, "description": {"en": None}, "i18n_properties": ["description"]}
+
+        application_area = Plugin.objects.get(pluginid="b2778828-a6ac-6481-c38b-fd463d878f1f")
+        application_area.config = workflow_existing_config
+        application_area.save()
+
+        communication = Plugin.objects.get(pluginid="4dc9bd5a-6e5c-440d-ae3c-af94396e2d72")
+        communication.config = workflow_existing_config
+        communication.save()
+
+        consultation = Plugin.objects.get(pluginid="a1667717-b7bd-4570-b27a-ec352c767e0e")
+        consultation.config = workflow_existing_config
+        consultation.save()
+
+        correspondence = Plugin.objects.get(pluginid="4bd762cf-b581-11e9-a7f9-784f435179ea")
+        correspondence.config = workflow_existing_config
+        correspondence.save()
+
+        site_visit = Plugin.objects.get(pluginid="0b1499e0-6cdc-403b-a2e3-499c2201069d")
+        site_visit.config = workflow_existing_config
+        site_visit.save()
+
+    def add_workflow_help_templates(apps, schema_editor):
+        Plugin = apps.get_model("models", "Plugin")
+
+        application_area = Plugin.objects.get(pluginid="b2778828-a6ac-6481-c38b-fd463d878f1f")
+        application_area.helptemplate = "application-area-workflow-help"
+        application_area.save()
+
+        communication = Plugin.objects.get(pluginid="4dc9bd5a-6e5c-440d-ae3c-af94396e2d72")
+        communication.helptemplate = "communication-workflow-help"
+        communication.save()
+
+        consultation = Plugin.objects.get(pluginid="a1667717-b7bd-4570-b27a-ec352c767e0e")
+        consultation.helptemplate = "consultation-workflow-help"
+        consultation.save()
+
+        correspondence = Plugin.objects.get(pluginid="4bd762cf-b581-11e9-a7f9-784f435179ea")
+        correspondence.helptemplate = "correspondence-workflow-help"
+        correspondence.save()
+
+        site_visit = Plugin.objects.get(pluginid="0b1499e0-6cdc-403b-a2e3-499c2201069d")
+        site_visit.helptemplate = "site-visit-workflow-help"
+        site_visit.save()
+
+    def remove_workflow_help_templates(apps, schema_editor):
+        Plugin = apps.get_model("models", "Plugin")
+
+        application_area = Plugin.objects.get(pluginid="b2778828-a6ac-6481-c38b-fd463d878f1f")
+        application_area.helptemplate = None
+        application_area.save()
+
+        communication = Plugin.objects.get(pluginid="4dc9bd5a-6e5c-440d-ae3c-af94396e2d72")
+        communication.helptemplate = None
+        communication.save()
+
+        consultation = Plugin.objects.get(pluginid="a1667717-b7bd-4570-b27a-ec352c767e0e")
+        consultation.helptemplate = None
+        consultation.save()
+
+        correspondence = Plugin.objects.get(pluginid="4bd762cf-b581-11e9-a7f9-784f435179ea")
+        correspondence.helptemplate = None
+        correspondence.save()
+
+        site_visit = Plugin.objects.get(pluginid="0b1499e0-6cdc-403b-a2e3-499c2201069d")
+        site_visit.helptemplate = None
+        site_visit.save()
+
 
     operations = [
         migrations.RunSQL(add_plugin_show_true_accessibility_activecons, remove_plugin_show_accessibility_activecons),
+        migrations.RunPython(workflow_config_update, revert_workflow_config),
+        migrations.RunPython(add_workflow_help_templates, remove_workflow_help_templates),
     ]

--- a/arches_her/migrations/0004_update_plugins.py
+++ b/arches_her/migrations/0004_update_plugins.py
@@ -95,6 +95,7 @@ class Migration(migrations.Migration):
             },
         ]
         init_workflow_plugin.config["workflows"] = workflows_config_list
+        init_workflow_plugin.save()
 
         # Revert config for each workflow plugin
         workflow_existing_config = {"show": False, "description": {"en": None}, "i18n_properties": ["description"]}

--- a/arches_her/migrations/0004_update_plugins.py
+++ b/arches_her/migrations/0004_update_plugins.py
@@ -6,20 +6,26 @@ class Migration(migrations.Migration):
 
     dependencies = [("arches_her", "0003_add_bng_search_view")]
 
-    accessibility_plugin = '8688eaf9-3605-4384-823c-d01c0d210f82'
-    active_consultations = '76a27df9-6f16-47ed-bd47-bb95c0fe7173'
+    accessibility_plugin = "8688eaf9-3605-4384-823c-d01c0d210f82"
+    active_consultations = "76a27df9-6f16-47ed-bd47-bb95c0fe7173"
 
     add_plugin_show_true_accessibility_activecons = """
         UPDATE plugins 
         SET config = jsonb_set(config, '{show}', 'true'::jsonb, true) 
         WHERE pluginid in ('%s','%s');
-        """ % (active_consultations, accessibility_plugin)
+        """ % (
+        active_consultations,
+        accessibility_plugin,
+    )
 
     remove_plugin_show_accessibility_activecons = """
         UPDATE plugins 
         SET config = config - 'show' 
         WHERE pluginid in ('%s','%s');
-        """ % (active_consultations, accessibility_plugin)
+        """ % (
+        active_consultations,
+        accessibility_plugin,
+    )
 
     def workflow_config_update(apps, scheme_editor):
         Plugin = apps.get_model("models", "Plugin")
@@ -30,12 +36,13 @@ class Migration(migrations.Migration):
         for wf_config in init_workflow_plugin.config["workflows"]:
             inner_worfklow_plugin = Plugin.objects.get(pluginid=wf_config["workflowid"])
 
-            inner_worfklow_plugin.config = {"show": False,
-                                            "is_workflow": True,
-                                            "description": wf_config["desc"],
-                                            "thumbnailBackgroundColor": wf_config["bgColor"],
-                                            "thumbnailCircleColor": wf_config["circleColor"],
-                                            }
+            inner_worfklow_plugin.config = {
+                "show": False,
+                "is_workflow": True,
+                "description": wf_config["desc"],
+                "thumbnailBackgroundColor": wf_config["bgColor"],
+                "thumbnailCircleColor": wf_config["circleColor"],
+            }
             inner_worfklow_plugin.save()
 
         # clear list from init-workflow (del list produces error)
@@ -165,7 +172,6 @@ class Migration(migrations.Migration):
         site_visit = Plugin.objects.get(pluginid="0b1499e0-6cdc-403b-a2e3-499c2201069d")
         site_visit.helptemplate = None
         site_visit.save()
-
 
     operations = [
         migrations.RunSQL(add_plugin_show_true_accessibility_activecons, remove_plugin_show_accessibility_activecons),

--- a/arches_her/migrations/0004_update_plugins.py
+++ b/arches_her/migrations/0004_update_plugins.py
@@ -6,21 +6,22 @@ class Migration(migrations.Migration):
 
     dependencies = [("arches_her", "0003_add_bng_search_view")]
 
-    # accessibility plugin = '8688eaf9-3605-4384-823c-d01c0d210f82'
-    # active consultations = '76a27df9-6f16-47ed-bd47-bb95c0fe7173'
+    accessibility_plugin = '8688eaf9-3605-4384-823c-d01c0d210f82'
+    active_consultations = '76a27df9-6f16-47ed-bd47-bb95c0fe7173'
 
-    add_plugin_show_true = """
+    add_plugin_show_true_accessibility_activecons = """
         UPDATE plugins 
         SET config = jsonb_set(config, '{show}', 'true'::jsonb, true) 
-        WHERE pluginid in ('76a27df9-6f16-47ed-bd47-bb95c0fe7173','8688eaf9-3605-4384-823c-d01c0d210f82');
-        """
+        WHERE pluginid in ('%s','%s');
+        """ % (active_consultations, accessibility_plugin)
 
-    remove_plugin_show = """
+    remove_plugin_show_accessibility_activecons = """
         UPDATE plugins 
         SET config = config - 'show' 
-        WHERE pluginid in ('76a27df9-6f16-47ed-bd47-bb95c0fe7173','8688eaf9-3605-4384-823c-d01c0d210f82');
-        """
+        WHERE pluginid in ('%s','%s');
+        """ % (active_consultations, accessibility_plugin)
+
 
     operations = [
-        migrations.RunSQL(add_plugin_show_true, remove_plugin_show),
+        migrations.RunSQL(add_plugin_show_true_accessibility_activecons, remove_plugin_show_accessibility_activecons),
     ]

--- a/arches_her/settings.py
+++ b/arches_her/settings.py
@@ -362,7 +362,6 @@ RENDERERS = [
     },
 ]
 
-X_FRAME_OPTIONS = "SAMEORIGIN"
 
 # By setting RESTRICT_MEDIA_ACCESS to True, media file requests outside of Arches will checked against nodegroup permissions.
 RESTRICT_MEDIA_ACCESS = False

--- a/arches_her/settings.py
+++ b/arches_her/settings.py
@@ -362,6 +362,8 @@ RENDERERS = [
     },
 ]
 
+X_FRAME_OPTIONS = "SAMEORIGIN"
+
 # By setting RESTRICT_MEDIA_ACCESS to True, media file requests outside of Arches will checked against nodegroup permissions.
 RESTRICT_MEDIA_ACCESS = False
 

--- a/arches_her/templates/help/application-area-workflow-help.htm
+++ b/arches_her/templates/help/application-area-workflow-help.htm
@@ -5,23 +5,26 @@
         <h4>{% trans "Application Area Workflow" %}</h4>
 
         <p>
-            This workflow X 
+            This workflow enables users to record an area that may be re-developed or newly built.
         </p>
 
         <h5><u>Required Information</u></h5>
         <ul>
-            <li></li>
+            <li>Application Area Name</li>
+            <li>Mapped Location (Geospatial Coordinates and/or Feature Shape)</li>
         </ul>
 
         <h5><u>Optional Information</u></h5>
         <ul>
-            <li></li>
+            <li>Location Description (and Description Type)</li>
+            <li>Associated Monument, Area or Artefact</li>
+            <li>Area Description (and Description Type)</li>
+            <li>Area Designations (and Description Type)</li>
         </ul>
 
         <h5><u>Workflow Outcomes</u></h5>
         <p>
-            Completion of this workflow will create a new X. 
-        </p>
+            Completion of this workflow will create a new Application Area resource instance.
         
     </div>
 </div>

--- a/arches_her/templates/help/application-area-workflow-help.htm
+++ b/arches_her/templates/help/application-area-workflow-help.htm
@@ -1,0 +1,27 @@
+{% load i18n %}
+
+<div class="ep-help-content">
+    <div>
+        <h4>{% trans "Application Area Workflow" %}</h4>
+
+        <p>
+            This workflow X 
+        </p>
+
+        <h5><u>Required Information</u></h5>
+        <ul>
+            <li></li>
+        </ul>
+
+        <h5><u>Optional Information</u></h5>
+        <ul>
+            <li></li>
+        </ul>
+
+        <h5><u>Workflow Outcomes</u></h5>
+        <p>
+            Completion of this workflow will create a new X. 
+        </p>
+        
+    </div>
+</div>

--- a/arches_her/templates/help/communication-workflow-help.htm
+++ b/arches_her/templates/help/communication-workflow-help.htm
@@ -1,0 +1,27 @@
+{% load i18n %}
+
+<div class="ep-help-content">
+    <div>
+        <h4>{% trans "Communication Workflow" %}</h4>
+
+        <p>
+            This workflow X 
+        </p>
+
+        <h5><u>Required Information</u></h5>
+        <ul>
+            <li></li>
+        </ul>
+
+        <h5><u>Optional Information</u></h5>
+        <ul>
+            <li></li>
+        </ul>
+
+        <h5><u>Workflow Outcomes</u></h5>
+        <p>
+            Completion of this workflow will create a new X. 
+        </p>
+        
+    </div>
+</div>

--- a/arches_her/templates/help/communication-workflow-help.htm
+++ b/arches_her/templates/help/communication-workflow-help.htm
@@ -5,12 +5,13 @@
         <h4>{% trans "Communication Workflow" %}</h4>
 
         <p>
-            This workflow X 
+            This workflow enables users to record communication via phone, email or other channels to a consultation resource.
         </p>
 
         <h5><u>Required Information</u></h5>
         <ul>
-            <li></li>
+            <li>Related Consultation</li>
+            <li>Communication Type</li>
         </ul>
 
         <h5><u>Optional Information</u></h5>
@@ -20,7 +21,7 @@
 
         <h5><u>Workflow Outcomes</u></h5>
         <p>
-            Completion of this workflow will create a new X. 
+            Completion of this workflow will create a new communication tile on the respective consultation resource instance. 
         </p>
         
     </div>

--- a/arches_her/templates/help/consultation-workflow-help.htm
+++ b/arches_her/templates/help/consultation-workflow-help.htm
@@ -5,22 +5,44 @@
         <h4>{% trans "Consultation Workflow" %}</h4>
 
         <p>
-            This workflow X 
+            This workflow enables users to record advice on potential work related to an application area.
         </p>
 
         <h5><u>Required Information</u></h5>
         <ul>
-            <li></li>
+            <li>Consultation Location (includes Geospatial Coordinates and Related Application Area)</li>
+            <li>Log and Target Dates</li>
+            <li>Consultation Type</li>
+            <li>Application Proposal Description</li>
         </ul>
 
         <h5><u>Optional Information</u></h5>
         <ul>
-            <li></li>
+            <li>Application Type</li>
+            <li>Development Type</li>
+            <li>Contested Heritage</li>
+            <li>Application Reference Numbers</li>
+            <ul>
+                <li>Reference</li>
+                <li>Reference Type</li>
+                <li>Agency</li>
+            </ul>
+            <li>Associated Proposal File(s)</li>
+            <li>Contacts</li>
+            <ul>
+                <li>Planning Officer</li>
+                <li>Planning Body</li>
+                <li>Consulting Contact</li>
+                <li>Casework Officer</li>
+                <li>Agent</li>
+                <li>Owner</li>
+                <li>Applicant</li>
+            </ul>
         </ul>
 
         <h5><u>Workflow Outcomes</u></h5>
         <p>
-            Completion of this workflow will create a new X. 
+            Completion of this workflow will create a new consultation resource instance. 
         </p>
         
     </div>

--- a/arches_her/templates/help/consultation-workflow-help.htm
+++ b/arches_her/templates/help/consultation-workflow-help.htm
@@ -1,0 +1,27 @@
+{% load i18n %}
+
+<div class="ep-help-content">
+    <div>
+        <h4>{% trans "Consultation Workflow" %}</h4>
+
+        <p>
+            This workflow X 
+        </p>
+
+        <h5><u>Required Information</u></h5>
+        <ul>
+            <li></li>
+        </ul>
+
+        <h5><u>Optional Information</u></h5>
+        <ul>
+            <li></li>
+        </ul>
+
+        <h5><u>Workflow Outcomes</u></h5>
+        <p>
+            Completion of this workflow will create a new X. 
+        </p>
+        
+    </div>
+</div>

--- a/arches_her/templates/help/correspondence-workflow-help.htm
+++ b/arches_her/templates/help/correspondence-workflow-help.htm
@@ -5,12 +5,13 @@
         <h4>{% trans "Correspondence Workflow" %}</h4>
 
         <p>
-            This workflow X 
+            This workflow enables users to create a letter or other document using existing data in the selected consultation resource instance.
         </p>
 
         <h5><u>Required Information</u></h5>
         <ul>
-            <li></li>
+            <li>Related Consultation</li>
+            <li>Letter Type</li>
         </ul>
 
         <h5><u>Optional Information</u></h5>
@@ -20,7 +21,7 @@
 
         <h5><u>Workflow Outcomes</u></h5>
         <p>
-            Completion of this workflow will create a new X. 
+            Completion of this workflow will create a new correspondence tile containing the generated Microsoft Word letter document on the respective consultation resource instance. 
         </p>
         
     </div>

--- a/arches_her/templates/help/correspondence-workflow-help.htm
+++ b/arches_her/templates/help/correspondence-workflow-help.htm
@@ -1,0 +1,27 @@
+{% load i18n %}
+
+<div class="ep-help-content">
+    <div>
+        <h4>{% trans "Correspondence Workflow" %}</h4>
+
+        <p>
+            This workflow X 
+        </p>
+
+        <h5><u>Required Information</u></h5>
+        <ul>
+            <li></li>
+        </ul>
+
+        <h5><u>Optional Information</u></h5>
+        <ul>
+            <li></li>
+        </ul>
+
+        <h5><u>Workflow Outcomes</u></h5>
+        <p>
+            Completion of this workflow will create a new X. 
+        </p>
+        
+    </div>
+</div>

--- a/arches_her/templates/help/site-visit-workflow-help.htm
+++ b/arches_her/templates/help/site-visit-workflow-help.htm
@@ -1,0 +1,27 @@
+{% load i18n %}
+
+<div class="ep-help-content">
+    <div>
+        <h4>{% trans "Site Visit Workflow" %}</h4>
+
+        <p>
+            This workflow X 
+        </p>
+
+        <h5><u>Required Information</u></h5>
+        <ul>
+            <li></li>
+        </ul>
+
+        <h5><u>Optional Information</u></h5>
+        <ul>
+            <li></li>
+        </ul>
+
+        <h5><u>Workflow Outcomes</u></h5>
+        <p>
+            Completion of this workflow will create a new X. 
+        </p>
+        
+    </div>
+</div>

--- a/arches_her/templates/help/site-visit-workflow-help.htm
+++ b/arches_her/templates/help/site-visit-workflow-help.htm
@@ -5,22 +5,30 @@
         <h4>{% trans "Site Visit Workflow" %}</h4>
 
         <p>
-            This workflow X 
+            This workflow enables users to create a letter or other document using existing data in the selected consultation resource instance.
         </p>
 
         <h5><u>Required Information</u></h5>
         <ul>
-            <li></li>
+            <li>Related Consultation</li>
+            <li>Date of Visit</li>
+            <li>Location Description</li>
         </ul>
 
         <h5><u>Optional Information</u></h5>
         <ul>
-            <li></li>
+            <li>Attendee</li>
+            <li>Attendee Type</li>
+            <li>Observation</li>
+            <li>Observed By</li>
+            <li>Recommendation</li>
+            <li>Recommended By</li>
+            <li>Site Photos (upload)</li>
         </ul>
 
         <h5><u>Workflow Outcomes</u></h5>
         <p>
-            Completion of this workflow will create a new X. 
+            Completion of this workflow will create a new site visit tile on the respective consultation resource instance. 
         </p>
         
     </div>

--- a/arches_her/templates/views/components/plugins/init-workflow.htm
+++ b/arches_her/templates/views/components/plugins/init-workflow.htm
@@ -78,6 +78,60 @@
                 {% trans 'Show Incomplete Workflows' %}
             </button>
 
+            <!-- Workflow Help button -->
+            <button 
+                class="btn btn-info btn-sm"
+                style="margin: 5px; margin-right: 10px; margin-left: 0px; border-radius: 4px;"
+                data-bind="
+                    click: function(){ $data.shouldShowWorkflowHelp(true); }
+                "
+            >
+                {% trans 'Show Workflow Help' %}
+            </button>
+        </div>
+
+        <div id="ep-help-panel" 
+            class="ep-help" 
+            style="display: none"
+            data-bind="slide: shouldShowWorkflowHelp, duration: 400, direction: {direction: 'right'}, easing: 'slide'"
+        >
+            <div class="ep-edits-header">
+                <div class="ep-help-title">
+                    <span>{% trans "Workflow Guidance" %}</span>
+                </div>
+                <a 
+                    href="javascript:void(0);" 
+                    class="ep-help-toggle ep-help-close ep-tools ep-tools-right" 
+                    style="border:none; box-sizing: content-box; padding: 0px 15px; background: #f1f1f1;"
+                    data-bind="click: function(){shouldShowWorkflowHelp(false); selectedHelpTemplate(null);}"
+                >
+                    <div class="" data-placement="bottom" data-toggle="tooltip" data-original-title="{% trans "Close Help" %}">
+                        <i class="fa fa-times-circle fa-lg"></i>
+                    </div>
+                </a>
+            </div>
+
+
+            <div style="padding: 20px;">
+                <select
+                    data-bind="
+                        select2Query: {
+                            select2Config: {
+                                clickBubble: false,
+                                disabled: false,
+                                data: $data.helpTemplateData,
+                                value: selectedHelpTemplate,
+                                dropdownCssClass: 'select2-zindex',
+                                closeOnSelect: true,
+                                allowClear: true,
+                                multiple: false,
+                                placeholder: '{% trans "Select A Workflow" %}'
+                            }
+                        }
+                    "
+                ></select>
+            </div>
+            
             <!-- ko if: $data.helpTemplateUrl() -->
                 <!-- ko if: $data.isHelpTemplateLoading() -->
                     <div class="loading-mask" style="bottom: unset; right: unset; left: 30%"></div>

--- a/arches_her/templates/views/components/plugins/init-workflow.htm
+++ b/arches_her/templates/views/components/plugins/init-workflow.htm
@@ -8,10 +8,14 @@
         <div class="workflow-incomplete-modal-container" data-bind="style: {maxWidth: $data.requestingUserIsSuperuser() ? '1200px' : '1000px'}">
             <div class="workflow-incomplete-modal-banner">
                 <button
+                    id="close-workflow-modal-btn"
                     aria-label="{% trans 'Close Incomplete Workflow Modal' %}"
                     tabindex="0"
                     class="close fa fa-times" style="font-size: 20px; cursor: pointer;"
-                    data-bind="click: function(){ $data.shouldShowIncompleteWorkflowsModal(false); }"
+                    data-bind="click: function(){
+                        $data.shouldShowIncompleteWorkflowsModal(false);
+                        $root.shiftFocus('#show-workflow-modal-btn');
+                    }"
                 ></button>
             </div>
             <div class="workflow-incomplete-modal-title">
@@ -68,22 +72,29 @@
         <div class="workflow-modal-buttons">
             <!-- Modal button -->
             <button 
+                id="show-workflow-modal-btn"
                 class="btn btn-info btn-sm"
                 style="margin: 5px; border-radius: 4px;"
                 data-bind="
                     enable: $data.incompleteWorkflows().length,
-                    click: function(){ $data.shouldShowIncompleteWorkflowsModal(true); }
+                    click: function(){
+                        $data.shouldShowIncompleteWorkflowsModal(true);
+                        $root.shiftFocus('#close-workflow-modal-btn');
+                    }
                 "
             >
                 {% trans 'Show Incomplete Workflows' %}
             </button>
 
             <!-- Workflow Help button -->
-            <button 
+            <button
+                id="show-workflow-help-btn"
                 class="btn btn-info btn-sm"
                 style="margin: 5px; margin-right: 10px; margin-left: 0px; border-radius: 4px;"
-                data-bind="
-                    click: function(){ $data.shouldShowWorkflowHelp(true); }
+                data-bind="click: function(){
+                    $data.shouldShowWorkflowHelp(true);
+                    $root.shiftFocus('#close-workflow-help-btn');
+                }
                 "
             >
                 {% trans 'Show Workflow Help' %}
@@ -99,11 +110,16 @@
                 <div class="ep-help-title">
                     <span>{% trans "Workflow Guidance" %}</span>
                 </div>
-                <a 
+                <a
+                    id="close-workflow-help-btn"
                     href="javascript:void(0);" 
                     class="ep-help-toggle ep-help-close ep-tools ep-tools-right" 
                     style="border:none; box-sizing: content-box; padding: 0px 15px; background: #f1f1f1;"
-                    data-bind="click: function(){shouldShowWorkflowHelp(false); selectedHelpTemplate(null);}"
+                    data-bind="click: function(){
+                        shouldShowWorkflowHelp(false); 
+                        selectedHelpTemplate(null);
+                        $root.shiftFocus('#show-workflow-help-btn');
+                    }"
                 >
                     <div class="" data-placement="bottom" data-toggle="tooltip" data-original-title="{% trans "Close Help" %}">
                         <i class="fa fa-times-circle fa-lg"></i>

--- a/arches_her/templates/views/components/plugins/init-workflow.htm
+++ b/arches_her/templates/views/components/plugins/init-workflow.htm
@@ -132,22 +132,17 @@
                 ></select>
             </div>
             
-            <!-- ko if: $data.helpTemplateUrl() -->
+            <!-- ko if: $data.helpTemplateHtml() -->
                 <!-- ko if: $data.isHelpTemplateLoading() -->
                     <div class="loading-mask" style="bottom: unset; right: unset; left: 30%"></div>
                 <!-- /ko -->
-                <iframe
-                    frameBorder="0"
-                    style="width: 100%; flex: 1;"
+                <div
+                    style="width: 100%; flex: 1; overflow: auto;"
                     data-bind="
                         style: { visibility: $data.isHelpTemplateLoading() ? 'hidden' : 'visible' },
-                        attr: {
-                            src: $data.helpTemplateUrl(), 
-                            onload: setTimeout(function(){$data.isHelpTemplateLoading(false)}, 500) 
-                        }
+                        html: $data.helpTemplateHtml()
                     "
-                >
-                </iframe>
+                ></div>
             <!-- /ko -->
         </div>
         <!-- /ko -->

--- a/arches_her/templates/views/components/plugins/init-workflow.htm
+++ b/arches_her/templates/views/components/plugins/init-workflow.htm
@@ -90,10 +90,10 @@
             </button>
         </div>
 
+        <!-- ko if: $data.shouldShowWorkflowHelp() -->
         <div id="ep-help-panel" 
             class="ep-help" 
-            style="display: none"
-            data-bind="slide: shouldShowWorkflowHelp, duration: 400, direction: {direction: 'right'}, easing: 'slide'"
+            style="display: flex; flex-direction: column; height: 100%;"
         >
             <div class="ep-edits-header">
                 <div class="ep-help-title">
@@ -136,11 +136,9 @@
                 <!-- ko if: $data.isHelpTemplateLoading() -->
                     <div class="loading-mask" style="bottom: unset; right: unset; left: 30%"></div>
                 <!-- /ko -->
-                
                 <iframe
-                    width="100%"
-                    height="100%"
                     frameBorder="0"
+                    style="width: 100%; flex: 1;"
                     data-bind="
                         style: { visibility: $data.isHelpTemplateLoading() ? 'hidden' : 'visible' },
                         attr: {
@@ -152,6 +150,7 @@
                 </iframe>
             <!-- /ko -->
         </div>
+        <!-- /ko -->
     </div>
 
     <div class="workflow-layout-afher">

--- a/arches_her/templates/views/components/plugins/init-workflow.htm
+++ b/arches_her/templates/views/components/plugins/init-workflow.htm
@@ -107,12 +107,12 @@
 
         <div class="workflow-select-card-container">
             <!-- ko foreach: {data: workflows, as: 'workflow'} -->
-            <a data-bind="attr: {href: workflow.url, title: workflow.name}" href="#"><div data-bind="style: {'background-color': workflow.bgColor}" class="workflow-select-card">
+            <a data-bind="attr: {href: workflow.url, title: workflow.name}" href="#"><div data-bind="style: {'background-color': workflow.config.thumbnailBackgroundColor}" class="workflow-select-card">
                 <h4 class="workflow-select-title" data-bind="text: workflow.name"></h4>
-                <div data-bind="style: {'background-color': workflow.circleColor}" class="workflow-select-wf-circle">
+                <div data-bind="style: {'background-color': workflow.config.thumbnailCircleColor}" class="workflow-select-wf-circle">
                     <span><i data-bind="attr:{class: ('fa '+workflow.icon +' workflow-select-wf-icon')}"></i></span>
                 </div>
-                <p data-bind="text: workflow.desc" class="workflow-select-desc"></p>
+                <p data-bind="text: workflow.config.description" class="workflow-select-desc"></p>
             </div></a>
             <!-- /ko -->
         </div>

--- a/arches_her/templates/views/components/plugins/init-workflow.htm
+++ b/arches_her/templates/views/components/plugins/init-workflow.htm
@@ -4,8 +4,8 @@
 
     <!-- Modal -->
     <!-- ko if: shouldShowIncompleteWorkflowsModal() -->
-    <div class="workflow-incomplete-modal-background">
-        <div class="workflow-incomplete-modal-container" data-bind="style: {maxWidth: $data.requestingUserIsSuperuser() ? '1200px' : '1000px'}">
+    <div class="workflow-incomplete-modal-background" role="presentation" data-bind="event: { keydown: $data.handleModalKeydown }">
+        <div class="workflow-incomplete-modal-container" role="dialog" aria-modal="true" aria-labelledby="workflow-modal-title" aria-describedby="workflow-modal-description" data-bind="style: {maxWidth: $data.requestingUserIsSuperuser() ? '1200px' : '1000px'}">
             <div class="workflow-incomplete-modal-banner">
                 <button
                     id="close-workflow-modal-btn"
@@ -19,44 +19,44 @@
                 ></button>
             </div>
             <div class="workflow-incomplete-modal-title">
-                <h2>{% trans 'Incomplete Workflows' %}</h2>
-                <p>
+                <h2 id="workflow-modal-title">{% trans 'Incomplete Workflows' %}</h2>
+                <p id="workflow-modal-description">
                     {% trans 'Please either complete or delete the workflows listed below.' %}
                 </p>
             </div>
 
             <div class="workflow-incomplete-modal-table">
-                <table class="table table-striped" style="border: 1px solid #ddd;">
+                <table class="table table-striped" role="table" aria-label="{% trans 'Incomplete Workflows' %}" style="border: 1px solid #ddd;">
                     <thead>
-                        <tr style="display: flex; justify-content: space-between;">
-                            <th style="flex-grow: 1; max-width: 200px;">
+                        <tr role="row" style="display: flex; justify-content: space-between;">
+                            <th role="columnheader" style="flex-grow: 1; max-width: 200px;">
                                 {% trans 'Created' %}
                             </th>
                             <!-- ko if: requestingUserIsSuperuser() -->
-                                <th style="flex-grow: 1; max-width: 200px;">
+                                <th role="columnheader" style="flex-grow: 1; max-width: 200px;">
                                     {% trans 'User' %}
                                 </th>
                             <!-- /ko -->
-                            <th style="flex-grow: 2; max-width: 400px;">
+                            <th role="columnheader" style="flex-grow: 2; max-width: 400px;">
                                 {% trans 'Workflow Name' %}
                             </th>
-                            <th style="flex-grow: 1; max-width: 200px;">
+                            <th role="columnheader" style="flex-grow: 1; max-width: 200px;">
                                 {% trans 'Link' %}
                             </th>
                         </tr>
                     </thead>
-                    <tbody style="display:block; overflow:auto; max-height:200px; width:100%;">
+                    <tbody role="rowgroup" style="display:block; overflow:auto; max-height:200px; width:100%;">
                         <!-- ko foreach: $data.incompleteWorkflows -->
-                        <tr style="display: flex; justify-content: space-between;">
-                            <td style="flex-grow: 1; max-width: 200px;" data-bind="text: $data.created"></td>
+                        <tr role="row" style="display: flex; justify-content: space-between;">
+                            <td role="cell" style="flex-grow: 1; max-width: 200px;" data-bind="text: $data.created"></td>
                             <!-- ko if: $parent.requestingUserIsSuperuser() -->
-                                <td style="flex-grow: 1; max-width: 200px;" data-bind="text: $data.username"></td>
+                                <td role="cell" style="flex-grow: 1; max-width: 200px;" data-bind="text: $data.username"></td>
                             <!-- /ko -->
-                            <td style="flex-grow: 2; max-width: 400px;" data-bind="text: $data.pluginname"></td>
-                            <td style="flex-grow: 1; max-width: 200px;">
+                            <td role="cell" style="flex-grow: 2; max-width: 400px;" data-bind="text: $data.pluginname"></td>
+                            <td role="cell" style="flex-grow: 1; max-width: 200px;">
                                 <a 
                                     data-bind="attr: {'href': `/plugins/${$data.workflowname}?workflow-id=${$data.workflowid}`}"
-                                    style="text-decoration: underline; color: blue;"
+                                    class="workflow-link"
                                 >{% trans 'Go to Workflow' %}</a>
                             </td>
                         </tr>
@@ -79,7 +79,6 @@
                     enable: $data.incompleteWorkflows().length,
                     click: function(){
                         $data.shouldShowIncompleteWorkflowsModal(true);
-                        $root.shiftFocus('#close-workflow-modal-btn');
                     }
                 "
             >
@@ -104,32 +103,38 @@
         <!-- ko if: $data.shouldShowWorkflowHelp() -->
         <div id="ep-help-panel" 
             class="ep-help" 
+            role="region"
+            aria-labelledby="workflow-help-title"
             style="display: flex; flex-direction: column; height: 100%;"
         >
             <div class="ep-edits-header">
                 <div class="ep-help-title">
-                    <span>{% trans "Workflow Guidance" %}</span>
+                    <span id="workflow-help-title">{% trans "Workflow Guidance" %}</span>
                 </div>
-                <a
+                <button
                     id="close-workflow-help-btn"
-                    href="javascript:void(0);" 
+                    type="button"
+                    aria-label="{% trans 'Close help panel' %}"
                     class="ep-help-toggle ep-help-close ep-tools ep-tools-right" 
-                    style="border:none; box-sizing: content-box; padding: 0px 15px; background: #f1f1f1;"
+                    style="border:none; box-sizing: content-box; padding: 0px 15px; background: #f1f1f1; cursor: pointer;"
                     data-bind="click: function(){
                         shouldShowWorkflowHelp(false); 
                         selectedHelpTemplate(null);
                         $root.shiftFocus('#show-workflow-help-btn');
                     }"
                 >
-                    <div class="" data-placement="bottom" data-toggle="tooltip" data-original-title="{% trans "Close Help" %}">
-                        <i class="fa fa-times-circle fa-lg"></i>
-                    </div>
-                </a>
+                    <span class="" data-placement="bottom" data-toggle="tooltip" data-original-title="{% trans "Close Help" %}">
+                        <i class="fa fa-times-circle fa-lg" aria-hidden="true"></i>
+                    </span>
+                </button>
             </div>
 
 
             <div style="padding: 20px;">
+                <label for="workflow-help-select" class="sr-only">{% trans "Select A Workflow" %}</label>
                 <select
+                    id="workflow-help-select"
+                    aria-label="{% trans 'Select A Workflow' %}"
                     data-bind="
                         select2Query: {
                             select2Config: {
@@ -150,9 +155,14 @@
             
             <!-- ko if: $data.helpTemplateHtml() -->
                 <!-- ko if: $data.isHelpTemplateLoading() -->
-                    <div class="loading-mask" style="bottom: unset; right: unset; left: 30%"></div>
+                    <div class="loading-mask" role="status" aria-live="polite" aria-label="{% trans 'Loading workflow help content' %}" style="bottom: unset; right: unset; left: 30%">
+                        <span class="sr-only">{% trans 'Loading...' %}</span>
+                    </div>
                 <!-- /ko -->
                 <div
+                    role="region"
+                    aria-live="polite"
+                    aria-label="{% trans 'Workflow help content' %}"
                     style="width: 100%; flex: 1; overflow: auto; padding: 0px 10px 0px 10px;"
                     data-bind="
                         style: { visibility: $data.isHelpTemplateLoading() ? 'hidden' : 'visible' },
@@ -171,7 +181,7 @@
 
         <div class="workflow-select-card-container">
             <!-- ko foreach: {data: workflows, as: 'workflow'} -->
-            <a data-bind="attr: {href: workflow.url, title: workflow.name}" href="#"><div data-bind="style: {'background-color': workflow.config.thumbnailBackgroundColor}" class="workflow-select-card">
+            <a data-bind="attr: {href: workflow.url, 'aria-label': workflow.name}" href="#"><div data-bind="style: {'background-color': workflow.config.thumbnailBackgroundColor}" class="workflow-select-card">
                 <h4 class="workflow-select-title" data-bind="text: workflow.name"></h4>
                 <div data-bind="style: {'background-color': workflow.config.thumbnailCircleColor}" class="workflow-select-wf-circle">
                     <span><i data-bind="attr:{class: ('fa '+workflow.icon +' workflow-select-wf-icon')}"></i></span>

--- a/arches_her/templates/views/components/plugins/init-workflow.htm
+++ b/arches_her/templates/views/components/plugins/init-workflow.htm
@@ -137,7 +137,7 @@
                     <div class="loading-mask" style="bottom: unset; right: unset; left: 30%"></div>
                 <!-- /ko -->
                 <div
-                    style="width: 100%; flex: 1; overflow: auto;"
+                    style="width: 100%; flex: 1; overflow: auto; padding: 0px 10px 0px 10px;"
                     data-bind="
                         style: { visibility: $data.isHelpTemplateLoading() ? 'hidden' : 'visible' },
                         html: $data.helpTemplateHtml()

--- a/releases/1.1.0.md
+++ b/releases/1.1.0.md
@@ -5,6 +5,7 @@ Arches for HERs 1.1.0 Release Notes
 
 - Retain placeholder text formatting for HTML (rich-text) values in consultation letters [#1365](https://github.com/archesproject/arches-her/pull/1365)
 - Adds new HTML export report template for Artefact resources [#1427](https://github.com/archesproject/arches-her/pull/1427)
+- Adds incomplete workflow modal and workflow help templates [#1447](https://github.com/archesproject/arches-her/pull/1447) 
 
 ### Dependency changes:
 ```


### PR DESCRIPTION
Closes #1443 

A couple of important points:
- This branch extends the existing 0004 migration rather than creating a new one, since 0004 refers to altering plugins and it seemed well placed there. To best test this PR:
   1. Unmigrate to 0003 on dev/1.1.x 
       `python manage.py migrate arches_her 0003`
   2. Fetch and checkout this git branch
   3. Migrate 0004 again
      `python manage.py migrate arches_her`
- The migration includes forward and backward for both individual and init-workflow config and help templates. 
For whatever reason, it doesn't seem possible to remove the `workflows: []` property from the object via python, so I've had to leave it empty.
- I've added some simple words to the help templates. The Communication and Correspondence help is currently unfinished due to current errors in the workflows preventing me from progressing and seeing which fields are required/optional.
- In AfS, the help menu uses the custom KoJS binding "slide", however I've used a flexbox layout to fix an issue on AfS where help information was showing in a small box and this has resulted in slide failing to work since it needs a fixed height. As a result, I've removed the slide animation, instead the window just reveals and hides as normal.
- The help templates are using an `iframe` which is blocked by default. I've added a line into settings.py [here](https://github.com/archesproject/arches-her/pull/1447/changes#diff-4fc5f6370d3adeb869cd4c088c851462a116f288417173addd846c21569df8aaR365) to fix this, but let me know if it shouldn't be there or should live elsewhere.