### PR TITLE
1466 only save sys ref tile when modified

### DIFF
--- a/arches_her/functions/generate_unique_references_function.py
+++ b/arches_her/functions/generate_unique_references_function.py
@@ -124,25 +124,21 @@ class GenerateUniqueReferences(BaseFunction):
 
             def simpleid_nextval_table_exists():
                 with connection.cursor() as cursor:
-                    cursor.execute(
-                        """
+                    cursor.execute("""
                         SELECT EXISTS (
                             SELECT FROM information_schema.tables 
                             WHERE  table_schema = 'public'
                             AND    table_name   = 'simpleid_nextval'
                         );
-                    """
-                    )
+                    """)
                     return bool(cursor.fetchone()[0])
 
             def get_next_simpleid():
                 with connection.cursor() as cursor:
-                    cursor.execute(
-                        """
+                    cursor.execute("""
                         TRUNCATE TABLE simpleid_nextval;
                         INSERT INTO simpleid_nextval DEFAULT VALUES RETURNING id;
-                    """
-                    )
+                    """)
                     return int(cursor.fetchone()[0])
 
             def get_simple_id_nodeinfo(functionid=None):
@@ -187,6 +183,9 @@ class GenerateUniqueReferences(BaseFunction):
                     currentTile.data[resid_node_id] = {language.code: {"value": resourceid_val, "direction": language.default_direction}}
                     return True
 
+                def get_formatted_id(id_string, language):
+                    return id_string[language.code]["value"]
+
                 try:
                     has_changes = False
                     simpleid = currentTile.data[simpleid_node]
@@ -205,7 +204,8 @@ class GenerateUniqueReferences(BaseFunction):
 
                     if currentTile.data[resid_node] is not None:
                         try:
-                            UUID(currentTile.data[resid_node])
+                            resid_string = get_formatted_id(currentTile.data[resid_node], default_language)
+                            UUID(resid_string)
                         except:
                             has_changes = populate_resid_id(currentTile, resid_node, resourceidval, default_language)
                     else:

--- a/arches_her/functions/generate_unique_references_function.py
+++ b/arches_her/functions/generate_unique_references_function.py
@@ -214,14 +214,14 @@ class GenerateUniqueReferences(BaseFunction):
                         try:
                             x = int(currentTile.data[simpleid_node])
                             self.logger.debug("Resource " + str(resourceidval) + "has valid simpleid: " + str(x))
-                        except:
+                        except (ValueError, TypeError):
                             has_changes = populate_simple_id(currentTile, simpleid_node)
 
                     if currentTile.data[resid_node] is not None:
                         try:
                             resid_string = get_formatted_id(currentTile.data[resid_node], default_language)
                             UUID(resid_string)
-                        except:
+                        except (ValueError, TypeError):
                             has_changes = populate_resid_id(currentTile, resid_node, resourceidval, default_language)
                     else:
                         has_changes = populate_resid_id(currentTile, resid_node, resourceidval, default_language)

--- a/arches_her/functions/generate_unique_references_function.py
+++ b/arches_her/functions/generate_unique_references_function.py
@@ -178,6 +178,7 @@ class GenerateUniqueReferences(BaseFunction):
                 def populate_simple_id(currentTile, simple_node_id):
                     nextsimpleval = get_next_simple_id()
                     currentTile.data[simple_node_id] = nextsimpleval
+                    return True
 
                 def populate_resid_id(currentTile, resid_node_id, resourceid_val, language):
                     currentTile.data[resid_node_id] = {language.code: {"value": resourceid_val, "direction": language.default_direction}}

--- a/arches_her/functions/generate_unique_references_function.py
+++ b/arches_her/functions/generate_unique_references_function.py
@@ -198,7 +198,7 @@ class GenerateUniqueReferences(BaseFunction):
 
                     default_language = models.Language.objects.get(code=settings.LANGUAGE_CODE)
 
-                    if currentTile.data.get(simpleid_node):
+                    if currentTile.data[simpleid_node] is not None and currentTile.data[simpleid_node] != 0:
                         try:
                             x = int(currentTile.data[simpleid_node])
                             self.logger.debug(f"Resource {resourceidval} has valid simpleid: {x}")
@@ -206,15 +206,6 @@ class GenerateUniqueReferences(BaseFunction):
                             has_changes = populate_simple_id(currentTile, simpleid_node)
                     else:
                         has_changes = populate_simple_id(currentTile, simpleid_node)
-
-                    if currentTile.data[simpleid_node] is None or currentTile.data[simpleid_node] == 0:
-                        has_changes = populate_simple_id(currentTile, simpleid_node)
-                    else:
-                        try:
-                            x = int(currentTile.data[simpleid_node])
-                            self.logger.debug("Resource " + str(resourceidval) + "has valid simpleid: " + str(x))
-                        except (ValueError, TypeError):
-                            has_changes = populate_simple_id(currentTile, simpleid_node)
 
                     if currentTile.data[resid_node] is not None:
                         try:

--- a/arches_her/functions/generate_unique_references_function.py
+++ b/arches_her/functions/generate_unique_references_function.py
@@ -196,8 +196,7 @@ class GenerateUniqueReferences(BaseFunction):
                 try:
                     has_changes = False
 
-                    languages = models.Language.objects.all()
-                    default_language = languages.get(code=settings.LANGUAGE_CODE)
+                    default_language = models.Language.objects.get(code=settings.LANGUAGE_CODE)
 
                     if currentTile.data.get(simpleid_node):
                         try:

--- a/arches_her/functions/generate_unique_references_function.py
+++ b/arches_her/functions/generate_unique_references_function.py
@@ -189,27 +189,23 @@ class GenerateUniqueReferences(BaseFunction):
 
                 try:
                     has_changes = False
+                    simpleid = currentTile.data[simpleid_node]
 
                     languages = models.Language.objects.all()
                     default_language = languages.get(code=settings.LANGUAGE_CODE)
 
-                    if currentTile.data[simpleid_node] is not None:
-                        if currentTile.data[simpleid_node] != 0:
-                            try:
-                                x = int(currentTile.data[simpleid_node])
-                                self.logger.debug("Resource " + str(resourceidval) + "has valid simpleid: " + str(x))
-                                pass
-                            except:
-                                has_changes = populate_simple_id(currentTile, simpleid_node)
-                        else:
-                            has_changes = populate_simple_id(currentTile, simpleid_node)
-                    else:
+                    if simpleid is None or simpleid == 0:
                         has_changes = populate_simple_id(currentTile, simpleid_node)
+                    else:
+                        try:
+                            x = int(currentTile.data[simpleid_node])
+                            self.logger.debug("Resource " + str(resourceidval) + "has valid simpleid: " + str(x))
+                        except:
+                            has_changes = populate_simple_id(currentTile, simpleid_node)
 
                     if currentTile.data[resid_node] is not None:
                         try:
                             UUID(currentTile.data[resid_node])
-                            pass
                         except:
                             has_changes = populate_resid_id(currentTile, resid_node, resourceidval, default_language)
                     else:

--- a/arches_her/functions/generate_unique_references_function.py
+++ b/arches_her/functions/generate_unique_references_function.py
@@ -199,6 +199,15 @@ class GenerateUniqueReferences(BaseFunction):
                     languages = models.Language.objects.all()
                     default_language = languages.get(code=settings.LANGUAGE_CODE)
 
+                    if currentTile.data.get(simpleid_node):
+                        try:
+                            x = int(currentTile.data[simpleid_node])
+                            self.logger.debug(f"Resource {resourceidval} has valid simpleid: {x}")
+                        except (ValueError, TypeError):
+                            has_changes = populate_simple_id(currentTile, simpleid_node)
+                    else:
+                        has_changes = populate_simple_id(currentTile, simpleid_node)
+
                     if currentTile.data[simpleid_node] is None or currentTile.data[simpleid_node] == 0:
                         has_changes = populate_simple_id(currentTile, simpleid_node)
                     else:

--- a/arches_her/functions/generate_unique_references_function.py
+++ b/arches_her/functions/generate_unique_references_function.py
@@ -185,7 +185,9 @@ class GenerateUniqueReferences(BaseFunction):
                     return True
 
                 def populate_resid_id(currentTile, resid_node_id, resourceid_val, language):
-                    currentTile.data[resid_node_id] = {language.code: {"value": resourceid_val, "direction": language.default_direction}}
+                    currentTile.data[resid_node_id] = {
+                        language.code: {"value": str(resourceid_val), "direction": language.default_direction}
+                    }
                     return True
 
                 def get_formatted_id(id_string, language):

--- a/arches_her/functions/generate_unique_references_function.py
+++ b/arches_her/functions/generate_unique_references_function.py
@@ -124,21 +124,25 @@ class GenerateUniqueReferences(BaseFunction):
 
             def simpleid_nextval_table_exists():
                 with connection.cursor() as cursor:
-                    cursor.execute("""
+                    cursor.execute(
+                        """
                         SELECT EXISTS (
                             SELECT FROM information_schema.tables 
                             WHERE  table_schema = 'public'
                             AND    table_name   = 'simpleid_nextval'
                         );
-                    """)
+                    """
+                    )
                     return bool(cursor.fetchone()[0])
 
             def get_next_simpleid():
                 with connection.cursor() as cursor:
-                    cursor.execute("""
+                    cursor.execute(
+                        """
                         TRUNCATE TABLE simpleid_nextval;
                         INSERT INTO simpleid_nextval DEFAULT VALUES RETURNING id;
-                    """)
+                    """
+                    )
                     return int(cursor.fetchone()[0])
 
             def get_simple_id_nodeinfo(functionid=None):

--- a/arches_her/functions/generate_unique_references_function.py
+++ b/arches_her/functions/generate_unique_references_function.py
@@ -183,12 +183,16 @@ class GenerateUniqueReferences(BaseFunction):
                     nextsimpleval = get_next_simple_id()
                     currentTile.data[simple_node_id] = nextsimpleval
 
-                def format_string_value(id_string_value):
-                    languages = models.Language.objects.all()
-                    default_language = languages.get(code=settings.LANGUAGE_CODE)
-                    return {default_language.code: {"value": id_string_value, "direction": default_language.default_direction}}
+                def populate_resid_id(currentTile, resid_node_id, resourceid_val, language):
+                    currentTile.data[resid_node_id] = {language.code: {"value": resourceid_val, "direction": language.default_direction}}
+                    return True
 
                 try:
+                    has_changes = False
+
+                    languages = models.Language.objects.all()
+                    default_language = languages.get(code=settings.LANGUAGE_CODE)
+
                     if currentTile.data[simpleid_node] is not None:
                         if currentTile.data[simpleid_node] != 0:
                             try:
@@ -196,22 +200,22 @@ class GenerateUniqueReferences(BaseFunction):
                                 self.logger.debug("Resource " + str(resourceidval) + "has valid simpleid: " + str(x))
                                 pass
                             except:
-                                populate_simple_id(currentTile, simpleid_node)
+                                has_changes = populate_simple_id(currentTile, simpleid_node)
                         else:
-                            populate_simple_id(currentTile, simpleid_node)
+                            has_changes = populate_simple_id(currentTile, simpleid_node)
                     else:
-                        populate_simple_id(currentTile, simpleid_node)
+                        has_changes = populate_simple_id(currentTile, simpleid_node)
 
                     if currentTile.data[resid_node] is not None:
                         try:
                             UUID(currentTile.data[resid_node])
                             pass
                         except:
-                            currentTile.data[resid_node] = format_string_value(str(resourceidval))
+                            has_changes = populate_resid_id(currentTile, resid_node, resourceidval, default_language)
                     else:
-                        currentTile.data[resid_node] = format_string_value(str(resourceidval))
+                        has_changes = populate_resid_id(currentTile, resid_node, resourceidval, default_language)
 
-                    return True
+                    return has_changes
 
                 except (
                     KeyboardInterrupt,

--- a/arches_her/functions/generate_unique_references_function.py
+++ b/arches_her/functions/generate_unique_references_function.py
@@ -195,12 +195,11 @@ class GenerateUniqueReferences(BaseFunction):
 
                 try:
                     has_changes = False
-                    simpleid = currentTile.data[simpleid_node]
 
                     languages = models.Language.objects.all()
                     default_language = languages.get(code=settings.LANGUAGE_CODE)
 
-                    if simpleid is None or simpleid == 0:
+                    if currentTile.data[simpleid_node] is None or currentTile.data[simpleid_node] == 0:
                         has_changes = populate_simple_id(currentTile, simpleid_node)
                     else:
                         try:


### PR DESCRIPTION
# Pull Request Template

This PR ensures that an existing system reference tile is only resaved (and hence re-indexed), if changes are made. 

It also rewrites the check for a valid resource id on that tile, to ensure it works with internationalised strings. 

## Types of changes

<!-- Put an `x` in the boxes that apply -->
- [X] Bugfix (non-breaking change which fixes an issue)

## Description of Change

A `has_changes` variable is created, which is set to `True` if either `populate_simple_id` or the newly created `populate_resid_id` are successfully called. The `check_and_populate_uids` then returns the `has_changes` value, rather than just automatically returning `True`. 

## Issues Solved

Closes https://github.com/archesproject/arches-her/issues/1466
Closes https://github.com/archesproject/arches-her/issues/1471

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->
- I targeted one of these branches:
  - [x] `dev/1.1.x` (default): features and bugfixes for the current release line
  - [ ] `dev/2.0.x` (next major): work intended for the next major release
- [ ] I added/updated a release note in `releases/` (if appropriate)
- [ ] I updated `README.md` (if setup/configuration/behaviour changed)
- [ ] Unit tests pass locally with my changes
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] My test fails on the target branch (if claiming this, explain below)

## Ticket Background

- Sponsored by: Knowledge Integration
- Found by: @CWDamm-Kint 
- Tested by: @CWDamm-Kint 
- Designed by: @CWDamm-Kint 
