### PR TITLE
1465 add refresh_tile_geojson_geometries to BNGPointToGeoJSON function

### DIFF
--- a/arches_her/functions/bngpoint_to_geojson_function.py
+++ b/arches_her/functions/bngpoint_to_geojson_function.py
@@ -184,6 +184,7 @@ class BNGPointToGeoJSON(BaseFunction):
 
             if self.config["geojson_nodegroup"] == str(tile.nodegroup_id):
                 tile.data[geojsonNode] = geometryValueJson
+                tile.save()
                 tileid_to_refresh = tile.tileid
             else:
                 previously_saved_tiles = Tile.objects.filter(

--- a/arches_her/functions/bngpoint_to_geojson_function.py
+++ b/arches_her/functions/bngpoint_to_geojson_function.py
@@ -209,10 +209,11 @@ class BNGPointToGeoJSON(BaseFunction):
                     new_geojson_tile.save()
 
             cursor = connection.cursor()
-            sql = """
-                    SELECT * FROM refresh_tile_geojson_geometries(%s);
-                """
-            cursor.execute(sql, (tile.tileid,))
+
+            cursor.execute(
+                "SELECT * FROM refresh_tile_geojson_geometries(%s);",
+                (tile.tileid,),
+            )
 
         else:
             pass

--- a/arches_her/functions/bngpoint_to_geojson_function.py
+++ b/arches_her/functions/bngpoint_to_geojson_function.py
@@ -180,8 +180,11 @@ class BNGPointToGeoJSON(BaseFunction):
             The new tile is saved and then the mv_geojson_geoms materialised view is refreshed so the point geometry will be displayed
             on the Search map.
             """
+            tileid_to_refresh = None
+
             if self.config["geojson_nodegroup"] == str(tile.nodegroup_id):
                 tile.data[geojsonNode] = geometryValueJson
+                tileid_to_refresh = tile.tileid
             else:
                 previously_saved_tiles = Tile.objects.filter(
                     nodegroup_id=self.config["geojson_nodegroup"], resourceinstance_id=tile.resourceinstance_id
@@ -197,6 +200,7 @@ class BNGPointToGeoJSON(BaseFunction):
                                 p.data[geojsonNode]["features"].append(f)
 
                         p.save()
+                        tileid_to_refresh = p.tileid
                 else:
                     new_geojson_tile = Tile().get_blank_tile_from_nodegroup_id(
                         self.config["geojson_nodegroup"], resourceid=tile.resourceinstance_id, parenttile=tile.parenttile
@@ -207,13 +211,15 @@ class BNGPointToGeoJSON(BaseFunction):
                         del new_geojson_tile.data[self.config["geojson_nodegroup"]]
 
                     new_geojson_tile.save()
+                    tileid_to_refresh = new_geojson_tile.tileid
 
             cursor = connection.cursor()
 
-            cursor.execute(
-                "SELECT * FROM refresh_tile_geojson_geometries(%s);",
-                (tile.tileid,),
-            )
+            if tileid_to_refresh:
+                cursor.execute(
+                    "SELECT * FROM refresh_tile_geojson_geometries(%s);",
+                    (str(tileid_to_refresh),),
+                )
 
         else:
             pass

--- a/arches_her/functions/bngpoint_to_geojson_function.py
+++ b/arches_her/functions/bngpoint_to_geojson_function.py
@@ -210,9 +210,9 @@ class BNGPointToGeoJSON(BaseFunction):
 
             cursor = connection.cursor()
             sql = """
-                    SELECT * FROM refresh_geojson_geometries();
+                    SELECT * FROM refresh_tile_geojson_geometries(%s);
                 """
-            cursor.execute(sql)  #
+            cursor.execute(sql, (tile.tileid,))
 
         else:
             pass


### PR DESCRIPTION
# Pull Request Template

`refresh_geojson_geometries` has been creating a bottleneck during saving in the BNGPointToGeoJSON function, when there are a large number of resources with geometries. As described in https://github.com/archesproject/arches-her/issues/1465, there is an alternative that only updates the geometry for the individual tile. 

## Types of changes

<!-- Put an `x` in the boxes that apply -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Involves changes to the Model/Graph, Concepts or Collections, or ontologies.

## Issues Solved

Closes https://github.com/archesproject/arches-her/issues/1465

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->
- I targeted one of these branches:
  - [x] `dev/1.1.x` (default): features and bugfixes for the current release line
  - [ ] `dev/2.0.x` (next major): work intended for the next major release
- [ ] I added/updated a release note in `releases/` (if appropriate)
- [ ] I updated `README.md` (if setup/configuration/behaviour changed)
- [ ] Unit tests pass locally with my changes
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] My test fails on the target branch (if claiming this, explain below)

## Ticket Background

- Sponsored by: Knowledge Integration
- Found by: @CWDamm-Kint 
- Tested by: @CWDamm-Kint 
- Designed by: @CWDamm-Kint 

